### PR TITLE
Update CI to main branch and latest xl2times & actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   push:
-    branches: [main]
+    branches: [ main ]
   pull_request:
 
 jobs:
@@ -10,42 +10,42 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
-        with:
-          path: head
+    - uses: actions/checkout@v4
+      with:
+        path: head
 
-      - name: Setup Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: 3.12
+    - name: Setup Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: 3.12
 
-      - name: Install xl2times
-        run: |
-          pip install -U pip
-          pip install xl2times==0.1.0
+    - name: Install xl2times
+      run: |
+        pip install -U pip
+        pip install xl2times==0.1.0
 
-      - name: Run raw_table_summary on TIMES-NZ-Model-Files
-        run: |
-          xl2times head/TIMES-NZ/ --output_dir head/TIMES-NZ/raw_table_summary/ --only_read
+    - name: Run raw_table_summary on TIMES-NZ-Model-Files
+      run: |
+        xl2times head/TIMES-NZ/ --output_dir head/TIMES-NZ/raw_table_summary/ --only_read
 
-      - name: Check if raw_table_summary is updated
-        id: raw_table_updated
-        run: |
-          cd head/TIMES-NZ/raw_table_summary
-          if ! git diff --quiet; then \
-            echo "ERROR: raw_table_summary is not up-to-date."; \
-            echo "The uploaded artifact contains the raw_table_summary for your branch, commit that to pass this check."; \
-            echo "See README for more details."; \
-            exit 1; fi
+    - name: Check if raw_table_summary is updated
+      id: raw_table_updated
+      run: |
+        cd head/TIMES-NZ/raw_table_summary
+        if ! git diff --quiet; then \
+          echo "ERROR: raw_table_summary is not up-to-date."; \
+          echo "The uploaded artifact contains the raw_table_summary for your branch, commit that to pass this check."; \
+          echo "See README for more details."; \
+          exit 1; fi
 
-      - name: Upload raw_tables.txt
-        uses: actions/upload-artifact@v3
-        if: ${{ failure() && steps.raw_table_updated.outcome == 'failure' }}
-        with:
-          name: raw_tables
-          path: head/TIMES-NZ/raw_table_summary/raw_tables.txt
+    - name: Upload raw_tables.txt
+      uses: actions/upload-artifact@v3
+      if: ${{ failure() && steps.raw_table_updated.outcome == 'failure' }}
+      with:
+        name: raw_tables
+        path: head/TIMES-NZ/raw_table_summary/raw_tables.txt
 
-      - name: Run times-excel-reader on TIMES-NZ-Model-Files
-        run: |
-          echo "Temporarily disabled. See https://github.com/EECA-NZ/TIMES-NZ-Model-Files/issue/10"
-          # times-excel-reader ../model # CURRENTLY BROKEN
+    - name: Run times-excel-reader on TIMES-NZ-Model-Files
+      run: |
+        echo "Temporarily disabled. See https://github.com/EECA-NZ/TIMES-NZ-Model-Files/issue/10"
+        # times-excel-reader ../model # CURRENTLY BROKEN

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   push:
-    branches: [ master ]
+    branches: [main]
   pull_request:
 
 jobs:
@@ -10,43 +10,42 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
-      with:
-        path: head
+      - uses: actions/checkout@v4
+        with:
+          path: head
 
-    - name: Setup Python
-      uses: actions/setup-python@v4
-      with:
-        python-version: 3.12
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: 3.12
 
-    - name: Clone and Install xl2times
-      run: |
-        git clone https://github.com/etsap-TIMES/xl2times.git
-        cd xl2times
-        pip install .
+      - name: Install xl2times
+        run: |
+          pip install -U pip
+          pip install xl2times==0.1.0
 
-    - name: Run raw_table_summary on TIMES-NZ-Model-Files
-      run: |
-        xl2times head/TIMES-NZ/ --output_dir head/TIMES-NZ/raw_table_summary/ --only_read
+      - name: Run raw_table_summary on TIMES-NZ-Model-Files
+        run: |
+          xl2times head/TIMES-NZ/ --output_dir head/TIMES-NZ/raw_table_summary/ --only_read
 
-    - name: Check if raw_table_summary is updated
-      id: raw_table_updated
-      run: |
-        cd head/TIMES-NZ/raw_table_summary
-        if ! git diff --quiet; then \
-          echo "ERROR: raw_table_summary is not up-to-date."; \
-          echo "The uploaded artifact contains the raw_table_summary for your branch, commit that to pass this check."; \
-          echo "See README for more details."; \
-          exit 1; fi
+      - name: Check if raw_table_summary is updated
+        id: raw_table_updated
+        run: |
+          cd head/TIMES-NZ/raw_table_summary
+          if ! git diff --quiet; then \
+            echo "ERROR: raw_table_summary is not up-to-date."; \
+            echo "The uploaded artifact contains the raw_table_summary for your branch, commit that to pass this check."; \
+            echo "See README for more details."; \
+            exit 1; fi
 
-    - name: Upload raw_tables.txt
-      uses: actions/upload-artifact@v3
-      if: ${{ failure() && steps.raw_table_updated.outcome == 'failure' }}
-      with:
-        name: raw_tables
-        path: head/TIMES-NZ/raw_table_summary/raw_tables.txt
+      - name: Upload raw_tables.txt
+        uses: actions/upload-artifact@v3
+        if: ${{ failure() && steps.raw_table_updated.outcome == 'failure' }}
+        with:
+          name: raw_tables
+          path: head/TIMES-NZ/raw_table_summary/raw_tables.txt
 
-    - name: Run times-excel-reader on TIMES-NZ-Model-Files
-      run: |
-        echo "Temporarily disabled. See https://github.com/EECA-NZ/TIMES-NZ-Model-Files/issue/10"
-        # times-excel-reader ../model # CURRENTLY BROKEN
+      - name: Run times-excel-reader on TIMES-NZ-Model-Files
+        run: |
+          echo "Temporarily disabled. See https://github.com/EECA-NZ/TIMES-NZ-Model-Files/issue/10"
+          # times-excel-reader ../model # CURRENTLY BROKEN


### PR DESCRIPTION
I noticed that this repo's CI is no longer running xl2times. This appears to be because the default branch was changed from master to main, and the CI yaml file wasn’t updated. If it would be helpful to have xl2times run on PRs and inform/warn developers of the diffs to Excel files, this PR should start running it again on PRs!

Hopefully super soon there will be a 0.2.0 release of xl2times that runs on the NZ model with 100% accuracy! 🤞 