### PR TITLE
Electricity Emission Factors update

### DIFF
--- a/PREPARE-TIMES-NZ/data_raw/coded_assumptions/emission_factors/emission_factors.csv
+++ b/PREPARE-TIMES-NZ/data_raw/coded_assumptions/emission_factors/emission_factors.csv
@@ -1,0 +1,37 @@
+﻿Fuel,Unit,CV MJ/Unit,EF kg CO2e/unit,Sector,SectorDetail,Year,Source
+Coal - Bituminous,kg,29.59,2.656,Industrial,,2023,https://environment.govt.nz/publications/measuring-emissions-a-guide-for-organisations-2024-detailed-guide/
+Coal - Sub-Bituminous,kg,21.64,2.005,Industrial,,2023,https://environment.govt.nz/publications/measuring-emissions-a-guide-for-organisations-2024-detailed-guide/
+Coal - Lignite,kg,15.26,1.43,Industrial,,2023,https://environment.govt.nz/publications/measuring-emissions-a-guide-for-organisations-2024-detailed-guide/
+LPG,kg,50,2.966,Industrial,,2023,https://environment.govt.nz/publications/measuring-emissions-a-guide-for-organisations-2024-detailed-guide/
+Diesel,Litre,38.49,2.671,Industrial,,2023,https://environment.govt.nz/publications/measuring-emissions-a-guide-for-organisations-2024-detailed-guide/
+Regular Petrol,Litre,35.24,2.373,Transport,,2023,https://environment.govt.nz/publications/measuring-emissions-a-guide-for-organisations-2024-detailed-guide/
+Premium Petrol,Litre,35.18,2.407,Transport,,2023,https://environment.govt.nz/publications/measuring-emissions-a-guide-for-organisations-2024-detailed-guide/
+Light Fuel Oil,Litre,40.45,2.963,Industrial,,2023,https://environment.govt.nz/publications/measuring-emissions-a-guide-for-organisations-2024-detailed-guide/
+Heavy Fuel Oil,Litre,40.74,3.046,Industrial,,2023,https://environment.govt.nz/publications/measuring-emissions-a-guide-for-organisations-2024-detailed-guide/
+Waste Oil,Litre,40.6,3.0045,Industrial,,2023,Mean of HFO and LFO
+Aviation fuel (Kerosene),Litre,37.19,2.516,Transport,,2023,https://environment.govt.nz/publications/measuring-emissions-a-guide-for-organisations-2024-detailed-guide/
+Natural Gas,GJ,1000,54.035,Industrial,,2023,https://environment.govt.nz/publications/measuring-emissions-a-guide-for-organisations-2024-detailed-guide/
+Landfill gas,kg,13.54,0.00069,Industrial,,2023,Greenhouse gas reporting: conversion factors 2022 - GOV.UK
+Biogas,kg,22,0.00122,Industrial,,2023,Greenhouse gas reporting: conversion factors 2022 - GOV.UK
+Wood - Chips,kg,15.15,0.023,Industrial,,2023,https://environment.govt.nz/publications/measuring-emissions-a-guide-for-organisations-2024-detailed-guide/
+Wood - Pellets,kg,18.99,0.029,Industrial,,2023,https://environment.govt.nz/publications/measuring-emissions-a-guide-for-organisations-2024-detailed-guide/
+Wood - Green,kg,8.89,0.014,Industrial,,2023,https://environment.govt.nz/publications/measuring-emissions-a-guide-for-organisations-2024-detailed-guide/
+Geothermal,kWh,3.6,0.062,Fugitive,Median,2023,"https://www.nzgeothermal.org.nz/geothermal-in-nz/what-is-geothermal/ (Note: applied to output generation, not input fuel)"
+Geothermal,kWh,3.6,0.045,Fugitive,25th percentile,2023,"https://www.nzgeothermal.org.nz/geothermal-in-nz/what-is-geothermal/ (Note: applied to output generation, not input fuel)"
+Geothermal,kWh,3.6,0.094,Fugitive,75th percentile,2023,"https://www.nzgeothermal.org.nz/geothermal-in-nz/what-is-geothermal/ (Note: applied to output generation, not input fuel)"
+Geothermal,kWh,3.6,0.076,Fugitive,Mean,2023,"https://www.nzgeothermal.org.nz/geothermal-in-nz/what-is-geothermal/ (Note: applied to output generation, not input fuel)"
+Geothermal,kWh,3.6,0.123,Fugitive,Kawerau,2023,"https://www.nzgeothermal.org.nz/geothermal-in-nz/what-is-geothermal/ (Note: applied to output generation, not input fuel)"
+Geothermal,kWh,3.6,0.052,Fugitive,Mokai,2023,"https://www.nzgeothermal.org.nz/geothermal-in-nz/what-is-geothermal/ (Note: applied to output generation, not input fuel)"
+Geothermal,kWh,3.6,0.063,Fugitive,Nga Awa Pūrua,2023,"https://www.nzgeothermal.org.nz/geothermal-in-nz/what-is-geothermal/ (Note: applied to output generation, not input fuel)"
+Geothermal,kWh,3.6,0.064,Fugitive,Ngā Tamariki,2023,"https://www.nzgeothermal.org.nz/geothermal-in-nz/what-is-geothermal/ (Note: applied to output generation, not input fuel)"
+Geothermal,kWh,3.6,0,Fugitive,Ngāwhā (OEC1-3),2023,"https://www.energyawards.co.nz/article/awards-finalist-ng%C4%81wh%C4%81-generation (Note: applied to output generation, not input fuel) (0 emissions)"
+Geothermal,kWh,3.6,0,Fugitive,Ngāwhā (OEC4),2023,https://www.energyawards.co.nz/article/awards-finalist-ng%C4%81wh%C4%81-generation
+Geothermal,kWh,3.6,0.341,Fugitive,Ōhaaki,2023,"https://www.nzgeothermal.org.nz/geothermal-in-nz/what-is-geothermal/ (Note: applied to output generation, not input fuel)"
+Geothermal,kWh,3.6,0.039,Fugitive,Poihipi,2023,"https://www.nzgeothermal.org.nz/geothermal-in-nz/what-is-geothermal/ (Note: applied to output generation, not input fuel)"
+Geothermal,kWh,3.6,0.084,Fugitive,Rotokawa,2023,"https://www.nzgeothermal.org.nz/geothermal-in-nz/what-is-geothermal/ (Note: applied to output generation, not input fuel)"
+Geothermal,kWh,3.6,0.06,Fugitive,Te Ahi O Maui,2023,"Assumed same factor as TOPP1, both on Kawerau field"
+Geothermal,kWh,3.6,0.045,Fugitive,Te Huka Binary,2023,"https://www.nzgeothermal.org.nz/geothermal-in-nz/what-is-geothermal/ (Note: applied to output generation, not input fuel)"
+Geothermal,kWh,3.6,0.043,Fugitive,Te Mihi,2023,"https://www.nzgeothermal.org.nz/geothermal-in-nz/what-is-geothermal/ (Note: applied to output generation, not input fuel)"
+Geothermal,kWh,3.6,0.06,Fugitive,TOPP1,2023,"https://www.nzgeothermal.org.nz/geothermal-in-nz/what-is-geothermal/ (Note: applied to output generation, not input fuel)"
+Geothermal,kWh,3.6,0.021,Fugitive,Wairakei,2023,"https://www.nzgeothermal.org.nz/geothermal-in-nz/what-is-geothermal/ (Note: applied to output generation, not input fuel)"
+Geothermal,kWh,3.6,0.021,Fugitive,Wairakei Binary,2023,"https://www.nzgeothermal.org.nz/geothermal-in-nz/what-is-geothermal/ (Note: applied to output generation, not input fuel)"

--- a/PREPARE-TIMES-NZ/data_raw/coded_assumptions/emission_factors/emission_factors.csv
+++ b/PREPARE-TIMES-NZ/data_raw/coded_assumptions/emission_factors/emission_factors.csv
@@ -24,8 +24,8 @@ Geothermal,kWh,3.6,0.123,Fugitive,Kawerau,2023,"https://www.nzgeothermal.org.nz/
 Geothermal,kWh,3.6,0.052,Fugitive,Mokai,2023,"https://www.nzgeothermal.org.nz/geothermal-in-nz/what-is-geothermal/ (Note: applied to output generation, not input fuel)"
 Geothermal,kWh,3.6,0.063,Fugitive,Nga Awa Pūrua,2023,"https://www.nzgeothermal.org.nz/geothermal-in-nz/what-is-geothermal/ (Note: applied to output generation, not input fuel)"
 Geothermal,kWh,3.6,0.064,Fugitive,Ngā Tamariki,2023,"https://www.nzgeothermal.org.nz/geothermal-in-nz/what-is-geothermal/ (Note: applied to output generation, not input fuel)"
-Geothermal,kWh,3.6,0,Fugitive,Ngāwhā (OEC1-3),2023,"https://www.energyawards.co.nz/article/awards-finalist-ng%C4%81wh%C4%81-generation (Note: applied to output generation, not input fuel) (0 emissions)"
-Geothermal,kWh,3.6,0,Fugitive,Ngāwhā (OEC4),2023,https://www.energyawards.co.nz/article/awards-finalist-ng%C4%81wh%C4%81-generation
+Geothermal,kWh,3.6,0.092,Fugitive,Ngāwhā (OEC1-3),2023,https://www.energyawards.co.nz/article/awards-finalist-ng%C4%81wh%C4%81-generation (Assumption of 30% of original 307g/kWh during CY 2023)
+Geothermal,kWh,3.6,0.092,Fugitive,Ngāwhā (OEC4),2023,https://www.energyawards.co.nz/article/awards-finalist-ng%C4%81wh%C4%81-generation (Assumption of 30% of original 307g/kWh during CY 2023)
 Geothermal,kWh,3.6,0.341,Fugitive,Ōhaaki,2023,"https://www.nzgeothermal.org.nz/geothermal-in-nz/what-is-geothermal/ (Note: applied to output generation, not input fuel)"
 Geothermal,kWh,3.6,0.039,Fugitive,Poihipi,2023,"https://www.nzgeothermal.org.nz/geothermal-in-nz/what-is-geothermal/ (Note: applied to output generation, not input fuel)"
 Geothermal,kWh,3.6,0.084,Fugitive,Rotokawa,2023,"https://www.nzgeothermal.org.nz/geothermal-in-nz/what-is-geothermal/ (Note: applied to output generation, not input fuel)"

--- a/PREPARE-TIMES-NZ/data_raw/user_config/VT_TIMESNZ_ELC.toml
+++ b/PREPARE-TIMES-NZ/data_raw/user_config/VT_TIMESNZ_ELC.toml
@@ -4,41 +4,62 @@ WorkBookName = "VT_TIMESNZ_ELC"
 
 ###############################################################################
 # Sector Fuels 
+
+# This sheet: 
+
+# 1: Defines commodities that can be used for electricity generation (eg ELCNGA)
+# 2: Defines the processes that can convert other TIMES Commodities into these fuels (eg NGA -> ELCNGA)
+# Note that these are effectively dummy processes for modelling, and so should not contain technical parameters. 
+# The processes are defined with 'PRE' settings (meaning 'miscellaneous') 
+
+# 3: Defines technical parameters for these proceses (barely used). 
+
+
+# NOTE: it is possible to add a VAROM to these processes to represent fuel delivery costs.
+#  However, these are now set to each electricity generating process separately 
+# (some plants have higher dlivery costs than others) by setting VAR_FLO costs on the process itself - this is the approach we have used, given the MBIE data on delivery costs.
 ###############################################################################
 
 [ElectricityFuelCommodityDefinitions]
-Description = "Defines commodities that can be used for electricity generation (eg ELCNGA)"
+
 SheetName = "Sector_Fuels_ELC"
 TagName = "FI_Comm"
+Description = "Defines commodities that can be used for electricity generation (eg ELCNGA)"
 DataLocation = "data_intermediate/stage_4_veda_format/base_year_elc/elc_input_commodity_definitions.csv"
 
 [ElectricityFuelProcessDefinitions]
-Description = "Defines the processes that can convert other TIMES Commodities into these fuels (eg NGA -> ELCNGA)"
-# Note that these are effectively dummy processes for modelling, and so should not contain technical parameters. 
-# The processes are defined with 'PRE' settings (meaning 'miscellaneous') 
+
 SheetName = "Sector_Fuels_ELC"
 TagName = "FI_Process"
+Description = "Defines the processes that can convert other TIMES Commodities into these fuels (eg NGA -> ELCNGA)"
 DataLocation = "data_intermediate/stage_4_veda_format/base_year_elc/elc_dummy_fuel_process_definitions.csv"
 
 [ElectricityFuelProcessParameters]
-Description = "Defines technical parameters for dummy electricity fuel processes (barely used)"
-# NOTE: it is possible to add a VAROM to these processes to represent fuel delivery costs.
-#  However, these are now set to each electricity generating process separately 
-# (some plants have higher delivery costs than others)
-# by setting VAR_FLO costs on the process itself - this is the approach we have used, given the MBIE data on delivery costs.
+
 SheetName = "Sector_Fuels_ELC"
 TagName = "FI_T"
+Description = "Defines technical parameters for dummy electricity fuel processes (barely used)"
 DataLocation = "data_intermediate/stage_4_veda_format/base_year_elc/elc_dummy_fuel_process_parameters.csv"
 
 ###############################################################################
 # Existing Technologies
+
+# This sheet: 
+
+# 1: Defines the ELC commodity 
+# 2: Defines all existing technologies capable of generating electricity 
+# 3: For each of these, adds detailed technical parameters  
+# 4: Adds age distributions for each plant or plant type (either NCAP_PASTI when lifetime is known, or PRC_RESID otherwise) 
 ###############################################################################
 
 
+
 [JustDefiningElectricity]
-Description = "Defines ELC and ELCCO2 (should these just be added to [ElectricityCommodityDefinitions]?)"
+
 SheetName = "Existing Technologies"
 TagName = "FI_Comm"
+Description = "Defines ELC and ELCCO2 (should these just be added to [ElectricityCommodityDefinitions]?)"
+
 # We will just put the relevant data in here for now. Copies specs from TIMES 2.0.
 # Alternatively could put a csv in data_raw and read that in to match the original. Not sure what's best. 
 [JustDefiningElectricity.Data]
@@ -53,102 +74,109 @@ Ctype =    ["ELC",  ""]
 
 
 [ElectricityProcessDefinitions]
-Description = "Defines all existing technologies capable of generating electricity"
 SheetName = "Existing Technologies"
 TagName = "FI_Process"
+Description = "Defines all existing technologies capable of generating electricity"
 DataLocation = "data_intermediate/stage_4_veda_format/base_year_elc/existing_tech_process_definitions.csv"
 
 
 [ElectricityProcessParameters]
-Description = "Technical parameters for existing electricity generation technologies"
 SheetName = "Existing Technologies"
 TagName = "FI_T"
+Description = "Technical parameters for existing electricity generation technologies"
 DataLocation = "data_intermediate/stage_4_veda_format/base_year_elc/existing_tech_parameters.csv"
 
 
 [ElectricityProcessAgeDistributions]
-Description = "Adds age distributions for each plant or plant type (either NCAP_PASTI when lifetime is known, or PRC_RESID to represent a capacity stock of mixed lifetimes otherwise)"
 SheetName = "Existing Technologies"
 TagName = "FI_T"
+Description = "Adds age distributions for each plant or plant type (either NCAP_PASTI when lifetime is known, or PRC_RESID otherwise) "
 # Some floating point errors creeping through into the generated data - need to check this.
 DataLocation = "data_intermediate/stage_4_veda_format/base_year_elc/existing_tech_capacity.csv"
 
+
+
+
+
 ###############################################################################
 # Distribution
-# Note: this sheet used to be called "Demand and Distribution". 
-# It contained a crude representation of own use which had been disabled from TIMES 2.0.
+
+# This sheet: 
+
+# 1: Defines all existing technologies capable of generating electricity 
+# 2: For each of these, adds detailed technical parameters  
+# 3: Adds age distributions for each plant or plant type (either NCAP_PASTI when lifetime is known, or PRC_RESID otherwise) 
+
+# Note: this sheet used to be called "Demand and Distribution". It contained a crude representation of own use which had been disabled from TIMES 2.0.
 # Since we use net generation this own use representation is not actually needed, so now the sheet is just called "Distribution".
 ###############################################################################
 
 
 [DistributionProcessDefinitions]
-Description = "Defines all processes involved in distribution (eg Processes that convert ELCHV to ELCMV)"
 SheetName = "Distribution"
 TagName = "FI_Process"
+Description = "Defines all distribution processes"
 DataLocation = "data_intermediate/stage_4_veda_format/base_year_elc/distribution_processes.csv"
 
 [DitributionCommodityDefinitions]
-Description = "Defines electricity distribution subprocessses (eg ELCHV, ELCMV, ELCDD)"
 SheetName = "Distribution"  
 TagName = "FI_Comm"
+Description = "Defines different ELC related to various stages of the transmission/distribution system"
 DataLocation = "data_intermediate/stage_4_veda_format/base_year_elc/distribution_commodities.csv"
 
 
 [DistributionProcessParameters]
-Description = "Sets technical parameters for distribution processes (eg losses, capacity, etc)" 
 SheetName = "Distribution"  
 TagName = "FI_T"
+Description = "Technical parameters for distribution processes" 
 DataLocation = "data_intermediate/stage_4_veda_format/base_year_elc/distribution_parameters.csv"
+
+
+
+
 
 ###############################################################################
 # Emission Factors 
 
 # This sheet applies emission factors to each electricity commodity. 
-# There is only one table needed and we can just define these assumptions here, as these are currently very simple.
-# In the future we might want to add more detail/sophistication, in which case this should be scripted instead.
 
-# The emissions factors are applied to the ELC commodity, and then the ELCCO2 commodity is defined as a function of ELC.
+# Note that geothermal emission factors are slightly different. These are defined based on the field output in kWh. 
+# This means they are not directly comparable to other fuel factors. 
+# In the model, we apply them to the activity (output flow) of the process, rather than the commodity use. 
 
-# EFS are from https://environment.govt.nz/publications/measuring-emissions-a-guide-for-organisations-2023-emission-factors-summary/
+# Key sources: 
 
-# Possible improvements: 
-
-#1: convert these all to co2e (this would be preferable) - would need to get CH4 and N2O factors, and convert via AR5
-#2: add geothermal EFs per field, and allow these to decrease over time if we want to integrate better future carbon capture.
-
-# Either of these approaches would require some scripting and input data, rather than hardcoding numbers in this config file.
+# https://environment.govt.nz/publications/measuring-emissions-a-guide-for-organisations-2024-detailed-guide/
+# https://www.nzgeothermal.org.nz/geothermal-in-nz/what-is-geothermal/ 
 
 ###############################################################################
 
 # Source: MEG 
 
 [ElectricityEmissionFactors]
-Description = "Defines emission factors for electricity generation. Sources and references listed in config file. Excludes CH4 and N2O."
+Description = "Defines co2e kt/PJ emission factors for electricity generation (input basis)."
 SheetName = "Emission Factors"  
 TagName = "COMEMI"
+DataLocation = "data_intermediate/stage_4_veda_format/emission_factors/emission_factors_elc_fuels.csv"
 
 
-[ElectricityEmissionFactors.Data]
-# THESE ARE ALL CO2, NOT C02e! (exclude CH4 and N20)
-CommName = "ELCCO2" # all the following pairs will make a column name and a value, so this defines the attribute.
+[GeothermalEmissionFactors]
+Description = "Defines co2e kt/PJ emission factors for geothermal electricity generation per field (output basis). Median value applied if plant data unavailable." 
+SheetName = "Emission Factors"
+TagName = "FI_T"
+DataLocation = "data_intermediate/stage_4_veda_format/emission_factors/emission_factors_geo.csv"
 
+[NgawhaEmissionFactorAdjustments]
+Description = "Manual adjustments to reduce Ngawha emissions to 0 by 2026. Note these are hardcoded assumptions in config file." 
+# Source: https://www.energyawards.co.nz/article/awards-finalist-ng%C4%81wh%C4%81-generation
+SheetName = "Emission Factors"
+TagName = "FI_T"
+# Define parameters: 
+[NgawhaEmissionFactorAdjustments.Data]
+# For these specific processes
+TechName =  ["ELC_Geothermal_GEO_Ngawha(oec1-3)", "ELC_Geothermal_GEO_Ngawha(oec4)"]
+# Set both to 0 by 2026 (must wrap variable in quotes when using ~)
+"ENV_ACT~ELCCO2~2026" = [0,0]
+# set standard linear interpolation and extrapolation
+"ENV_ACT~ELCCO2~0" = [5,5]
 
-# all values are kg/GJ, which are equal to kt/PJ (our model units)
-ELCCOA = 92.20 # GCV basis - need to be careful that all our PJs are in gross terms (so use the gross balances)
-# Note: Coal use for electricity generation from: 
-# https://environment.govt.nz/assets/publications/climate-change/New-Zealands-Greenhouse-Gas-Inventory-1990-2021-Annexes.pdf
-# Table A4.2 page 142
-# This assumes all sub-bit coal. We don't distinguish between sub-bit and bit coal in the model, so this is a reasonable assumption.
-
-# Natural gas
-ELCNGA = 53.61
-# Diesel (we just call oil but it's all diesel) (assumes 10ppt sulphur)
-ELCOIL = 69.45 
-
-# all co2 is biogenic and doesn't count, so these become zero. We may need to update this. 
-ELCBIG = 0
-ELCWOD = 0
-
-# Geothermal - CURRENTLY ONLY ONE GENERAL EF 
-# This figure is from TIMES 2.0. It needs updating. It won't be CO2, either - fugitive methane? 
-ELCGEO = 23.89

--- a/PREPARE-TIMES-NZ/data_raw/user_config/VT_TIMESNZ_ELC.toml
+++ b/PREPARE-TIMES-NZ/data_raw/user_config/VT_TIMESNZ_ELC.toml
@@ -77,7 +77,7 @@ DataLocation = "data_intermediate/stage_4_veda_format/base_year_elc/existing_tec
 # Distribution
 # Note: this sheet used to be called "Demand and Distribution". 
 # It contained a crude representation of own use which had been disabled from TIMES 2.0.
-# Since we use net generation this own use representation is not actually needed, so now the sheet is just called "Distribution".
+# Since don't use that "Own Use" anymore the sheet is just called "Distribution".
 ###############################################################################
 
 
@@ -143,7 +143,7 @@ SheetName = "Emission Factors"
 TagName = "FI_T"
 # Define parameters: 
 [NgawhaEmissionFactorAdjustments.Data]
-# For these specific processes
+# For these specific processes (NOTE hardcoding to match generated process names)
 TechName =  ["ELC_Geothermal_GEO_Ngawha(oec1-3)", "ELC_Geothermal_GEO_Ngawha(oec4)"]
 # Set both to 0 by 2026 (must wrap variable in quotes when using ~)
 "ENV_ACT~ELCCO2~2026" = [0,0]

--- a/PREPARE-TIMES-NZ/data_raw/user_config/VT_TIMESNZ_ELC.toml
+++ b/PREPARE-TIMES-NZ/data_raw/user_config/VT_TIMESNZ_ELC.toml
@@ -4,62 +4,41 @@ WorkBookName = "VT_TIMESNZ_ELC"
 
 ###############################################################################
 # Sector Fuels 
-
-# This sheet: 
-
-# 1: Defines commodities that can be used for electricity generation (eg ELCNGA)
-# 2: Defines the processes that can convert other TIMES Commodities into these fuels (eg NGA -> ELCNGA)
-# Note that these are effectively dummy processes for modelling, and so should not contain technical parameters. 
-# The processes are defined with 'PRE' settings (meaning 'miscellaneous') 
-
-# 3: Defines technical parameters for these proceses (barely used). 
-
-
-# NOTE: it is possible to add a VAROM to these processes to represent fuel delivery costs.
-#  However, these are now set to each electricity generating process separately 
-# (some plants have higher dlivery costs than others) by setting VAR_FLO costs on the process itself - this is the approach we have used, given the MBIE data on delivery costs.
 ###############################################################################
 
 [ElectricityFuelCommodityDefinitions]
-
+Description = "Defines commodities that can be used for electricity generation (eg ELCNGA)"
 SheetName = "Sector_Fuels_ELC"
 TagName = "FI_Comm"
-Description = "Defines commodities that can be used for electricity generation (eg ELCNGA)"
 DataLocation = "data_intermediate/stage_4_veda_format/base_year_elc/elc_input_commodity_definitions.csv"
 
 [ElectricityFuelProcessDefinitions]
-
+Description = "Defines the processes that can convert other TIMES Commodities into these fuels (eg NGA -> ELCNGA)"
+# Note that these are effectively dummy processes for modelling, and so should not contain technical parameters. 
+# The processes are defined with 'PRE' settings (meaning 'miscellaneous') 
 SheetName = "Sector_Fuels_ELC"
 TagName = "FI_Process"
-Description = "Defines the processes that can convert other TIMES Commodities into these fuels (eg NGA -> ELCNGA)"
 DataLocation = "data_intermediate/stage_4_veda_format/base_year_elc/elc_dummy_fuel_process_definitions.csv"
 
 [ElectricityFuelProcessParameters]
-
+Description = "Defines technical parameters for dummy electricity fuel processes (barely used)"
+# NOTE: it is possible to add a VAROM to these processes to represent fuel delivery costs.
+#  However, these are now set to each electricity generating process separately 
+# (some plants have higher delivery costs than others)
+# by setting VAR_FLO costs on the process itself - this is the approach we have used, given the MBIE data on delivery costs.
 SheetName = "Sector_Fuels_ELC"
 TagName = "FI_T"
-Description = "Defines technical parameters for dummy electricity fuel processes (barely used)"
 DataLocation = "data_intermediate/stage_4_veda_format/base_year_elc/elc_dummy_fuel_process_parameters.csv"
 
 ###############################################################################
 # Existing Technologies
-
-# This sheet: 
-
-# 1: Defines the ELC commodity 
-# 2: Defines all existing technologies capable of generating electricity 
-# 3: For each of these, adds detailed technical parameters  
-# 4: Adds age distributions for each plant or plant type (either NCAP_PASTI when lifetime is known, or PRC_RESID otherwise) 
 ###############################################################################
 
 
-
 [JustDefiningElectricity]
-
+Description = "Defines ELC and ELCCO2 (should these just be added to [ElectricityCommodityDefinitions]?)"
 SheetName = "Existing Technologies"
 TagName = "FI_Comm"
-Description = "Defines ELC and ELCCO2 (should these just be added to [ElectricityCommodityDefinitions]?)"
-
 # We will just put the relevant data in here for now. Copies specs from TIMES 2.0.
 # Alternatively could put a csv in data_raw and read that in to match the original. Not sure what's best. 
 [JustDefiningElectricity.Data]
@@ -74,64 +53,52 @@ Ctype =    ["ELC",  ""]
 
 
 [ElectricityProcessDefinitions]
+Description = "Defines all existing technologies capable of generating electricity"
 SheetName = "Existing Technologies"
 TagName = "FI_Process"
-Description = "Defines all existing technologies capable of generating electricity"
 DataLocation = "data_intermediate/stage_4_veda_format/base_year_elc/existing_tech_process_definitions.csv"
 
 
 [ElectricityProcessParameters]
+Description = "Technical parameters for existing electricity generation technologies"
 SheetName = "Existing Technologies"
 TagName = "FI_T"
-Description = "Technical parameters for existing electricity generation technologies"
 DataLocation = "data_intermediate/stage_4_veda_format/base_year_elc/existing_tech_parameters.csv"
 
 
 [ElectricityProcessAgeDistributions]
+Description = "Adds age distributions for each plant or plant type (either NCAP_PASTI when lifetime is known, or PRC_RESID to represent a capacity stock of mixed lifetimes otherwise)"
 SheetName = "Existing Technologies"
 TagName = "FI_T"
-Description = "Adds age distributions for each plant or plant type (either NCAP_PASTI when lifetime is known, or PRC_RESID otherwise) "
 # Some floating point errors creeping through into the generated data - need to check this.
 DataLocation = "data_intermediate/stage_4_veda_format/base_year_elc/existing_tech_capacity.csv"
 
-
-
-
-
 ###############################################################################
 # Distribution
-
-# This sheet: 
-
-# 1: Defines all existing technologies capable of generating electricity 
-# 2: For each of these, adds detailed technical parameters  
-# 3: Adds age distributions for each plant or plant type (either NCAP_PASTI when lifetime is known, or PRC_RESID otherwise) 
-
-# Note: this sheet used to be called "Demand and Distribution". It contained a crude representation of own use which had been disabled from TIMES 2.0.
+# Note: this sheet used to be called "Demand and Distribution". 
+# It contained a crude representation of own use which had been disabled from TIMES 2.0.
 # Since we use net generation this own use representation is not actually needed, so now the sheet is just called "Distribution".
 ###############################################################################
 
 
 [DistributionProcessDefinitions]
+Description = "Defines all processes involved in distribution (eg Processes that convert ELCHV to ELCMV)"
 SheetName = "Distribution"
 TagName = "FI_Process"
-Description = "Defines all distribution processes"
 DataLocation = "data_intermediate/stage_4_veda_format/base_year_elc/distribution_processes.csv"
 
 [DitributionCommodityDefinitions]
+Description = "Defines electricity distribution subprocessses (eg ELCHV, ELCMV, ELCDD)"
 SheetName = "Distribution"  
 TagName = "FI_Comm"
-Description = "Defines different ELC related to various stages of the transmission/distribution system"
 DataLocation = "data_intermediate/stage_4_veda_format/base_year_elc/distribution_commodities.csv"
 
 
 [DistributionProcessParameters]
+Description = "Sets technical parameters for distribution processes (eg losses, capacity, etc)" 
 SheetName = "Distribution"  
 TagName = "FI_T"
-Description = "Technical parameters for distribution processes" 
 DataLocation = "data_intermediate/stage_4_veda_format/base_year_elc/distribution_parameters.csv"
-
-
 
 
 
@@ -148,6 +115,9 @@ DataLocation = "data_intermediate/stage_4_veda_format/base_year_elc/distribution
 
 # https://environment.govt.nz/publications/measuring-emissions-a-guide-for-organisations-2024-detailed-guide/
 # https://www.nzgeothermal.org.nz/geothermal-in-nz/what-is-geothermal/ 
+
+# Finally, we assume some emissions from Ngawha in the base year, and that these fall to zero by 2026. 
+# This is hardcoded below.
 
 ###############################################################################
 

--- a/PREPARE-TIMES-NZ/docs/model_methodology/base_year_electricity.md
+++ b/PREPARE-TIMES-NZ/docs/model_methodology/base_year_electricity.md
@@ -73,7 +73,15 @@ These include:
  - Distribution parameters `DistributionAssumptions.csv` - these are the assumed distribution and transmission parameters from older versions of TIMES.
  - Other assumptions per technology `TechnologyAssumptions.csv` - these are other assumptions per technology, including plant technical life and peak contribution rates.
 
+# Emission factor data and assumptions
 
+Emission factor raw inputs can be found in `data_raw/coded_assumptions/emission_factors/emission_factors.csv`. 
+
+These are based on data from: 
+
+ - The [2024 Measuring Emissions Guide](https://environment.govt.nz/publications/measuring-emissions-a-guide-for-organisations-2024-detailed-guide/)
+ - NZ Geothermal's [2018 Emission Factors](https://www.nzgeothermal.org.nz/geothermal-in-nz/what-is-geothermal/)
+ - Additional assumptions on [Ngawha's decarbonisation program](https://www.energyawards.co.nz/article/awards-finalist-ng%C4%81wh%C4%81-generation)
 
 # Detailed method
 
@@ -195,12 +203,22 @@ Assumptions on current transmission capacity, costs, and losses, have been extra
 
 ## 10 Emissions factors
 
-Emissions factors are defined for each commodity in the user config file stage_0_config/VT_TIMESNZ_ELC.toml.
+Emission factor assumptions are (almost) all defined in `data_raw/coded_assumptions/emission_factors/emission_factors.csv`. Some adjustments are currently made in the config file, specifically for Ngāwhā's generation. This file lists relevant sources, and is heavily based on work previously done for EECA's emission factors by Achini Weerasinghe. 
 
-These are pulled from MFE data on emissions factors for fuels used in the power sector. Note that they include only c02 (not ch4 or n02) and are based on GCV of fuels. We should most likely use Gross Calorific values for other fuel inputs in the model, or at least be consistent in this approach. 
+Emission factors are processed directly from the raw data to TIMES output files in `scripts/stage_4_veda_format/create_emission_factor_files.py`.
 
-Note that geothermal emission factors are copied from TIMES 2.0. These may need to be updated and sourced better. 
-We may also wish to add more sophistication to the geothermal factors - either adjusting these between plants, or allowing them to fall in the future if we expect greater carbon reinjection at specific sites. Currently there is only one emissions factor for all geothermal plants at all times. 
+### Thermal fuel emission factors 
+
+The emission factors come in a range of units, and are all converted to CO2-e/PJ. Factors from the assumptions worksheet are directly mapped to TIMES commodities. We use industrial emission factors from MfE and apply these to electricity generation. Coal emission factors use sub-bituminous values.
+
+Note that these are based on gross calorific values.
+
+### Geothermal emission factors 
+For geothermal emissions, the factors are delivered in CO2-e/kWh. We therefore instead map these to the activity for geothermal plants (ie, the output electricity, rather than the input fuel as for thermal plants.)
+
+These are specified on a per-plant basis, using data from [NZ Geothermal](https://www.nzgeothermal.org.nz/geothermal-in-nz/what-is-geothermal/). Geothermal plants can have a wide range of fugitive emission values, depending on the chemical makeup of the field. If emission factors for a field are unknown, we apply the median value. 
+
+For Ngāwhā, we assume the 2023 emissions are much lower than the 2018 values, following Ngāwhā Generation's work in decarbonising emissions from these fields. We set emissions to an assumed 30% of 2018 values. Further, in the config file we create additional parameters to TIMES, which will reduce Ngāwhā emissions to 0 by 2026, following company announcements.
 
 ## 11 Adding TIMES features
 

--- a/PREPARE-TIMES-NZ/library/helpers.py
+++ b/PREPARE-TIMES-NZ/library/helpers.py
@@ -3,6 +3,7 @@ import os
 #from openpyxl import Workbook, load_workbook
 # from ast import literal_eval
 import pandas as pd 
+import polars as pl
 # import string
 import shutil 
 import logging
@@ -42,23 +43,27 @@ def clear_output():
 
 def select_and_rename(df, name_map):
     """
-    Selects and renames columns in a DataFrame based on a provided mapping.
+    Selects and renames columns in a Pandas or Polars DataFrame based on a provided mapping.
     
     Parameters:
-    - df: The input DataFrame.
+    - df: The input DataFrame (pandas.DataFrame or polars.DataFrame).
     - name_map: A dictionary where keys are the original column names and values are the new column names.
     
     Returns:
-    - A DataFrame with selected and renamed columns.
+    - A DataFrame with selected and renamed columns, same type as input.
     """
-    # Select columns based on the mapping
-    selected_df = df[list(name_map.keys())].copy()
-    
-    # Rename columns
-    selected_df.rename(columns=name_map, inplace=True)
-    
-    return selected_df
+    if isinstance(df, pd.DataFrame):
+        selected_df = df[list(name_map.keys())]
+        return selected_df.rename(columns=name_map)
 
+    elif isinstance(df, pl.DataFrame):
+        selected_df = df.select(list(name_map.keys()))
+        for old, new in name_map.items():
+            selected_df = selected_df.rename({old: new})
+        return selected_df
+
+    else:
+        raise TypeError("Input must be a pandas or polars DataFrame")
 
 
 

--- a/PREPARE-TIMES-NZ/scripts/prepare_times_nz.py
+++ b/PREPARE-TIMES-NZ/scripts/prepare_times_nz.py
@@ -53,6 +53,7 @@ run_script(f"{STAGE_2_SCRIPTS}/baseyear_electricity_generation.py")
 #Stage 4: Create excel files 
 print(f"Reshaping data to match Veda formatting...")    
 run_script(f"{STAGE_4_SCRIPTS}/create_baseyear_ELC_files.py")    
+run_script(f"{STAGE_4_SCRIPTS}/create_emission_factor_files.py")  
 print(f"Building TIMES excel files based on .toml configuration files...")    
 run_script(f"{STAGE_4_SCRIPTS}/write_excel.py")    
     

--- a/PREPARE-TIMES-NZ/scripts/stage_4_veda_format/create_emission_factor_files.py
+++ b/PREPARE-TIMES-NZ/scripts/stage_4_veda_format/create_emission_factor_files.py
@@ -1,0 +1,136 @@
+"""
+EECA's emission factors worksheet is already mostly compiled. We convert these into kt/PJ
+
+"""
+#######################################################################
+#region LIBRARIES 
+#######################################################################
+import sys 
+import os 
+import polars as pl
+import pandas as pd
+
+current_dir = os.path.dirname(os.path.abspath(__file__))
+sys.path.append(os.path.join(current_dir, "../..", "library"))
+from filepaths import DATA_RAW, DATA_INTERMEDIATE
+from helpers import select_and_rename
+
+input_location = f"{DATA_RAW}/coded_assumptions/emission_factors"
+stage_2_data_location = f"{DATA_INTERMEDIATE}/stage_2_baseyear"
+output_location = f"{DATA_INTERMEDIATE}/stage_4_veda_format/emission_factors"
+os.makedirs(output_location, exist_ok = True)
+
+
+#endregion
+#######################################################################
+#region GET_DATA
+#######################################################################
+
+emission_factors_df = f"{input_location}/emission_factors.csv" 
+emission_factors_df = pl.read_csv(emission_factors_df)
+
+# calculate the kt/co2e for every fuel 
+emission_factors_df = (
+    emission_factors_df
+    .with_columns((pl.col("EF kg CO2e/unit")/pl.col("CV MJ/Unit")).alias("kg/MJ"))
+    .with_columns((pl.col("kg/MJ")*1e3).alias("kt CO2e/PJ"))
+    )
+
+# We also need the data from our full plant list 
+
+plant_data = pl.read_csv(f"{stage_2_data_location}/base_year_electricity_supply.csv")
+#endregion 
+
+#######################################################################
+#region ELECTRICITY_GENERATION
+#######################################################################
+
+# In future, once we have more emission factors in this script, we should maybe
+# extract the full mapping to an external concordance file for raw input and greater visibility
+
+elec_ef_mapping =  {
+    "Coal - Sub-Bituminous" : "ELCCOA",
+    "Natural Gas" : "ELCNGA",
+    "Diesel" : "ELCOIL", # We call this oil but it's assumed all diesel (no fuel oil generation anymore)  (assumes 10ppt sulphur)
+    "Biogas" : "ELCBIG",
+    "Wood - Pellets" : "ELCWOD", # an argument for instead taking other wood types, or the mean of other wood types. They're all quite similar.
+    }
+# modify the table 
+emission_factors_elc = (
+    emission_factors_df
+    # using the industrial EFs for electricity generation
+    .filter(pl.col("Sector") == "Industrial")
+    # taking the fuels specified in the mapping
+    .filter(pl.col("Fuel").is_in(list(elec_ef_mapping.keys())))
+    # and then renaming them based on the map 
+    .with_columns(pl.col("Fuel").replace(elec_ef_mapping).alias("FuelCode"))  
+    # add the TIMES CommName with a polars literal
+    .with_columns(pl.lit("ELCCO2").alias("CommName"))  
+    )
+
+# select and rename 
+emission_factors_elc_names = {
+    "CommName" : "CommName",
+    "FuelCode":"Fuel",     
+    "kt CO2e/PJ" : "Value"
+    }
+emission_factors_elc = select_and_rename(emission_factors_elc,emission_factors_elc_names)
+
+# pivot for TIMES format 
+emission_factors_elc = (emission_factors_elc
+                        .pivot(values = "Value",
+                               index = "CommName", # the index is also our attribute name which Veda needs 
+                               on = "Fuel"))
+
+# save the file
+emission_factors_elc.write_csv(f"{output_location}/emission_factors_elc_fuels.csv")
+
+
+#endregion
+########################################################################
+#region GEOTHERMAL_EMISSION_FACTORS
+#######################################################################
+
+# Geothermal data from emission factors assumption file 
+geothermal_df = (emission_factors_df.filter(pl.col("Fuel") == "Geothermal")                 )
+
+# Extract median value for geothermal emissions factor as default value
+default_geo_factor = (
+    geothermal_df
+    # Select median 
+    .filter(pl.col("SectorDetail") == "Median")
+    # extract the first value as a variable
+    )["kt CO2e/PJ"].to_list()[0]
+
+# select and rename the emission factors data so we can join it to our plant names 
+geo_name_map = {
+    "SectorDetail" : "CommName",
+    "kt CO2e/PJ" : "Value",
+    "SectorDetail" : "PlantName", # for joining the values to our main table 
+}
+
+geothermal_df = select_and_rename(geothermal_df, geo_name_map)
+
+# Create the table from our main plant data and adding the above inputs. 
+geo_plant_emission_factors = (
+    # start with our list of geothermal plant names 
+    plant_data 
+    .filter(pl.col("FuelType") == "Geothermal")
+    .select(["PlantName", "Process"])
+    .unique()    
+    .sort("PlantName") # Not necessary but makes me happy. 
+    # These are our main plant names from the original genstack input at data_raw/coded_assumptions/electricity_generation/GenerationFleet.csv
+    # They should match the appropriate plants in the raw emission factors assumption inputs. 
+    .join(geothermal_df, on = "PlantName", how = "left")
+    # If no factor is found, we use the default median factor
+    .with_columns(pl.col("Value").fill_null(default_geo_factor))
+    # Now we add the relevant variables for TIMES 
+    # This sheet would need to be more complicated if we wanted different factors for different years. This is probably fine for now.
+    .rename({"Process" : "TechName",
+             "Value": "ENV_ACT~ELCCO2"})
+    .select(["TechName","ENV_ACT~ELCCO2"])
+
+)
+
+# Save
+geo_plant_emission_factors.write_csv(f"{output_location}/emission_factors_geo.csv")


### PR DESCRIPTION
Previously, we just copied the emission factors we could find from TIMES 2.0. These appeared to be CO2 (not CO2-e), and it was difficult to replicate the source of the geothermal emission factors. This was not ideal. 

We have made the following improvements: 

- Clear input data and sources from MfE's 2024 Measuring Emissions Guide for thermal fuels. 
- Changed to using GCV CO2-e values, so now includes non-zero emissions for biomass and biogas.
- Geothermal emission factors per plant where available, using NZGeothermal emission factors data.
- An adjustment to bring Ngawha generation emissions to 0 by 2026 following company accouncements.
- Room to expand this method to other fuels and use types for other areas of TIMES.

Potential Improvements ------------

Currently, the mapping between emission factors in the raw file and the relevant TIMES commodity is done directly in the processing script. This might be done better as an input concordance file, so that the mapping could be centralised for better visibility. It would be best to consider all the other non-electricity emission factors if implementing that approach. 

Notes -------------

Fugitive geothermal emission factors are applied to the output generation. All other emissions (based on combustion) are applied to the use of the relevant commodity. This means the two are not directly comparable and are implemented differently in the model. 

Finally, I experimented using polars instead of pandas for the processing script. I think I like the syntax better? This also means I had to generalise a helper function to work with pandas or polars. 