### PR TITLE
FIx Industry I/O

### DIFF
--- a/PREPARE-TIMES-NZ/scripts/stage_3_scenarios/industry/industry_get_demand_growth.py
+++ b/PREPARE-TIMES-NZ/scripts/stage_3_scenarios/industry/industry_get_demand_growth.py
@@ -20,8 +20,8 @@ import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
 import seaborn as sns
+from prepare_times_nz.stage_2.industry.common import CHECKS_DIR, INDUSTRY_ASSUMPTIONS
 from prepare_times_nz.utilities.filepaths import (
-    ASSUMPTIONS,
     DATA_INTERMEDIATE,
     STAGE_2_DATA,
 )
@@ -30,7 +30,6 @@ from prepare_times_nz.utilities.logger_setup import logger
 # Filepaths --------
 
 STAGE_2_INDUSTRY_DATA = f"{STAGE_2_DATA}/industry"
-INDUSTRY_ASSUMPTIONS = f"{ASSUMPTIONS}/industry_demand"
 OUTPUT_PATH = (
     DATA_INTERMEDIATE
     / Path("stage_3_scenario_data")
@@ -58,18 +57,14 @@ def get_demand_settings():
     return df
 
 
-def get_aggregate_data():
+def get_aggregate_data(checks_dir=CHECKS_DIR):
     """
-    Docstring needed
+    Load the TIMES sector's disaggregated timeseries data
+    (ie an EEUD timeseries with Methanex disaggregation etc)
+    THen summarise for total energy demand per sector
     """
 
-    times_eeud_alignment_timeseries_csv_path = (
-        Path(STAGE_2_INDUSTRY_DATA)
-        / "checks"
-        / "1_sector_alignment"
-        / "times_eeud_alignment_timeseries.csv"
-    )
-    df = pd.read_csv(times_eeud_alignment_timeseries_csv_path)
+    df = pd.read_csv(checks_dir / "times_eeud_alignment_timeseries.csv")
     df = df.groupby(["Year", "Sector"])["Value"].sum().reset_index()
     return df
 

--- a/PREPARE-TIMES-NZ/src/prepare_times_nz/stage_2/industry/common.py
+++ b/PREPARE-TIMES-NZ/src/prepare_times_nz/stage_2/industry/common.py
@@ -16,7 +16,7 @@ from prepare_times_nz.utilities.logger_setup import blue_text, logger
 
 # Constants ------------------------------------------------
 BASE_YEAR = 2023
-RUN_TESTS = False
+RUN_TESTS = True
 CAP2ACT = 31.536
 
 # Filepaths ------------------------------------------------

--- a/PREPARE-TIMES-NZ/src/prepare_times_nz/stage_2/industry/industry_add_assumptions.py
+++ b/PREPARE-TIMES-NZ/src/prepare_times_nz/stage_2/industry/industry_add_assumptions.py
@@ -106,7 +106,9 @@ def main() -> None:
     """Script entrypoint"""
     df = pd.read_csv(PREPROCESSING_DIR / PREPRO_DF_NAME_STEP2)
     df = get_industry_assumptions(df)
-    save_preprocessing(df, PREPRO_DF_NAME_STEP3, "3_times_baseyear_with_assumptions")
+    save_preprocessing(
+        df, PREPRO_DF_NAME_STEP3, "industry baseyear data with assumptions"
+    )
 
 
 if __name__ == "__main__":

--- a/PREPARE-TIMES-NZ/src/prepare_times_nz/stage_2/industry/industry_define_process_commodities.py
+++ b/PREPARE-TIMES-NZ/src/prepare_times_nz/stage_2/industry/industry_define_process_commodities.py
@@ -64,26 +64,25 @@ Tweaks
 # ----------------------------------------------------------------------------
 from __future__ import annotations
 
-import os
 from typing import List
 
 import numpy as np
 import pandas as pd
-from prepare_times_nz.utilities.csv_writers import save_dataframe_to_csv
-from prepare_times_nz.utilities.filepaths import CONCORDANCES, STAGE_2_DATA
+from prepare_times_nz.stage_2.industry.common import (
+    INDUSTRY_CONCORDANCES,
+    PREPRO_DF_NAME_STEP3,
+    PREPRO_DF_NAME_STEP4,
+    PREPROCESSING_DIR,
+    RUN_TESTS,
+    save_checks,
+    save_preprocessing,
+)
 from prepare_times_nz.utilities.logger_setup import logger
 
 # ----------------------------------------------------------------------------
 # Constants
 # ----------------------------------------------------------------------------
-RUN_TESTS: bool = True
 
-OUTPUT_LOCATION = f"{STAGE_2_DATA}/industry/preprocessing"
-CHECKS_LOCATION = f"{STAGE_2_DATA}/industry/checks/4_process_commodity_definitions"
-os.makedirs(OUTPUT_LOCATION, exist_ok=True)
-os.makedirs(CHECKS_LOCATION, exist_ok=True)
-
-INDUSTRY_CONCORDANCES = f"{CONCORDANCES}/industry"
 
 # Concordance tables – loaded at import time so they are module‑level constants
 USE_CODES = pd.read_csv(f"{INDUSTRY_CONCORDANCES}/use_codes.csv")
@@ -186,20 +185,22 @@ def make_wide(df: pd.DataFrame) -> pd.DataFrame:
 def main() -> None:
     """Entrypoint for running the process/commodity definition stage."""
     # Input table
-    df = pd.read_csv(f"{OUTPUT_LOCATION}/3_times_baseyear_with_assumptions.csv")
+    df = pd.read_csv(PREPROCESSING_DIR / PREPRO_DF_NAME_STEP3)
 
     # Transform
     df = define_process_commodities(df)
 
     # Save outputs
-    save_dataframe_to_csv(
-        df, OUTPUT_LOCATION, "4_times_baseyear_with_commodity_definitions.csv"
+    save_preprocessing(
+        df,
+        PREPRO_DF_NAME_STEP4,
+        "baseyear industry data with commodity and process definitions",
     )
 
     df_wide = make_wide(df)
-    save_dataframe_to_csv(
+
+    save_checks(
         df_wide,
-        CHECKS_LOCATION,
         "baseyear_with_commodities_wide.csv",
         label="data in wide format",
     )


### PR DESCRIPTION
Industry scripts were breaking in the new method because loading data on import rather than being protected by main guard 

tidied up the inconsistent i/o function and filename treatment in these industry scrtipts too, and updated the forecast script to match 

it's still loading some stuff on import but these are hardcoded assumption files. Should probably tidy the IO on these too for best practice


