### PR TITLE
first attempt at fixing ordering

### DIFF
--- a/PREPARE-TIMES-NZ/scripts/stage_0_settings/parse_tomls.py
+++ b/PREPARE-TIMES-NZ/scripts/stage_0_settings/parse_tomls.py
@@ -29,7 +29,9 @@ from typing import List
 
 import pandas as pd
 import tomli_w
-from prepare_times_nz.stage_0.generate_documentation import main as document
+from prepare_times_nz.stage_0.generate_documentation import (
+    main as generate_documentation,
+)
 from prepare_times_nz.stage_0.toml_readers import parse_toml_file
 from prepare_times_nz.utilities.filepaths import DATA_INTERMEDIATE, DATA_RAW
 
@@ -114,7 +116,7 @@ def main() -> None:
         logger.warning("No TOML files found in %s", RAW_DATA_LOCATION)
 
     # generate documentation
-    document()
+    generate_documentation()
     logger.info("Generating documentation")
 
 

--- a/PREPARE-TIMES-NZ/src/prepare_times_nz/stage_0/generate_documentation.py
+++ b/PREPARE-TIMES-NZ/src/prepare_times_nz/stage_0/generate_documentation.py
@@ -53,7 +53,8 @@ def create_workbook_categories(df):
         )
         n += 1
 
-    df = df.sort_values("Order")
+    # sort by category, and alphabetically by workbookname within each category
+    df = df.sort_values(["Order", "WorkBookName"])
 
     return df
 

--- a/docs/model-structure.md
+++ b/docs/model-structure.md
@@ -16,36 +16,37 @@ Documents are organised by broad category.
 ### Base year (Historical) data
 
 
- - [VT_TIMESNZ_ELC.xlsx](model_structure_docs/VT_TIMESNZ_ELC.md)
- - [VT_TIMESNZ_COM.xlsx](model_structure_docs/VT_TIMESNZ_COM.md)
- - [VT_TIMESNZ_RES.xlsx](model_structure_docs/VT_TIMESNZ_RES.md)
- - [VT_TIMESNZ_PRI.xlsx](model_structure_docs/VT_TIMESNZ_PRI.md)
  - [VT_TIMESNZ_AGR.xlsx](model_structure_docs/VT_TIMESNZ_AGR.md)
+ - [VT_TIMESNZ_COM.xlsx](model_structure_docs/VT_TIMESNZ_COM.md)
+ - [VT_TIMESNZ_ELC.xlsx](model_structure_docs/VT_TIMESNZ_ELC.md)
  - [VT_TIMESNZ_IND.xlsx](model_structure_docs/VT_TIMESNZ_IND.md)
+ - [VT_TIMESNZ_PRI.xlsx](model_structure_docs/VT_TIMESNZ_PRI.md)
+ - [VT_TIMESNZ_RES.xlsx](model_structure_docs/VT_TIMESNZ_RES.md)
  - [VT_TIMESNZ_TRA.xlsx](model_structure_docs/VT_TIMESNZ_TRA.md)
  - [BY_Trans.xlsx](model_structure_docs/BY_Trans.md)
 ### Standard scenario
 
 
- - [SuppXLS/Scen_LoadCurve_COM-FR.xlsx](model_structure_docs/SuppXLS_Scen_LoadCurve_COM-FR.md)
- - [SuppXLS/Scen_LNG_build_timing.xlsx](model_structure_docs/SuppXLS_Scen_LNG_build_timing.md)
- - [SuppXLS/Scen_EAFDemand_Transformation.xlsx](model_structure_docs/SuppXLS_Scen_EAFDemand_Transformation.md)
- - [SuppXLS/Scen_EAFDemand_Traditional.xlsx](model_structure_docs/SuppXLS_Scen_EAFDemand_Traditional.md)
- - [SuppXLS/Scen_DiscountRates_Transformation.xlsx](model_structure_docs/SuppXLS_Scen_DiscountRates_Transformation.md)
- - [SuppXLS/Scen_DiscountRates_Traditional.xlsx](model_structure_docs/SuppXLS_Scen_DiscountRates_Traditional.md)
- - [SuppXLS/Scen_WEM_WCM.xlsx](model_structure_docs/SuppXLS_Scen_WEM_WCM.md)
- - [SuppXLS/Scen_ContingentGas.xlsx](model_structure_docs/SuppXLS_Scen_ContingentGas.md)
- - [SuppXLS/Scen_Carbon_Transformation.xlsx](model_structure_docs/SuppXLS_Scen_Carbon_Transformation.md)
+ - [SuppXLS/Scen_Base_Constraints.xlsx](model_structure_docs/SuppXLS_Scen_Base_Constraints.md)
  - [SuppXLS/Scen_Carbon_Traditional.xlsx](model_structure_docs/SuppXLS_Scen_Carbon_Traditional.md)
- - [SuppXLS/Scen_ProcessHeatCoalBan.xlsx](model_structure_docs/SuppXLS_Scen_ProcessHeatCoalBan.md)
+ - [SuppXLS/Scen_Carbon_Transformation.xlsx](model_structure_docs/SuppXLS_Scen_Carbon_Transformation.md)
+ - [SuppXLS/Scen_ContingentGas.xlsx](model_structure_docs/SuppXLS_Scen_ContingentGas.md)
+ - [SuppXLS/Scen_DiscountRates_Traditional.xlsx](model_structure_docs/SuppXLS_Scen_DiscountRates_Traditional.md)
+ - [SuppXLS/Scen_DiscountRates_Transformation.xlsx](model_structure_docs/SuppXLS_Scen_DiscountRates_Transformation.md)
+ - [SuppXLS/Scen_EAFDemand_Traditional.xlsx](model_structure_docs/SuppXLS_Scen_EAFDemand_Traditional.md)
+ - [SuppXLS/Scen_EAFDemand_Transformation.xlsx](model_structure_docs/SuppXLS_Scen_EAFDemand_Transformation.md)
+ - [SuppXLS/Scen_LNG_build_timing.xlsx](model_structure_docs/SuppXLS_Scen_LNG_build_timing.md)
+ - [SuppXLS/Scen_LoadCurve_COM-FR.xlsx](model_structure_docs/SuppXLS_Scen_LoadCurve_COM-FR.md)
  - [SuppXLS/Scen_NewTechDemand.xlsx](model_structure_docs/SuppXLS_Scen_NewTechDemand.md)
+ - [SuppXLS/Scen_ProcessHeatCoalBan.xlsx](model_structure_docs/SuppXLS_Scen_ProcessHeatCoalBan.md)
  - [SuppXLS/Scen_Renewable_Availability.xlsx](model_structure_docs/SuppXLS_Scen_Renewable_Availability.md)
+ - [SuppXLS/Scen_WEM_WCM.xlsx](model_structure_docs/SuppXLS_Scen_WEM_WCM.md)
 ### Demand scenario
 
 
- - [SuppXLS/Demands/ScenDem_Transformation.xlsx](model_structure_docs/SuppXLS_Demands_ScenDem_Transformation.md)
  - [SuppXLS/Demands/Dem_Alloc+Series.xlsx](model_structure_docs/SuppXLS_Demands_Dem_Alloc+Series.md)
  - [SuppXLS/Demands/ScenDem_Traditional.xlsx](model_structure_docs/SuppXLS_Demands_ScenDem_Traditional.md)
+ - [SuppXLS/Demands/ScenDem_Transformation.xlsx](model_structure_docs/SuppXLS_Demands_ScenDem_Transformation.md)
 ### Inter-regional trade
 
 
@@ -54,15 +55,15 @@ Documents are organised by broad category.
 ### SubRES: Optional expansion of Reference Energy System
 
 
- - [SubRES_TMPL/SubRES_NewTechs_ELC_Transformation.xlsx](model_structure_docs/SubRES_TMPL_SubRES_NewTechs_ELC_Transformation.md)
- - [SubRES_TMPL/SubRES_NewTechs_COM.xlsx](model_structure_docs/SubRES_TMPL_SubRES_NewTechs_COM.md)
- - [SubRES_TMPL/SubRES_NewTechs_ELC_Transformation_trans.xlsx](model_structure_docs/SubRES_TMPL_SubRES_NewTechs_ELC_Transformation_trans.md)
- - [SubRES_TMPL/SubRES_SectorClosures.xlsx](model_structure_docs/SubRES_TMPL_SubRES_SectorClosures.md)
- - [SubRES_TMPL/SubRES_NewTechs_IND.xlsx](model_structure_docs/SubRES_TMPL_SubRES_NewTechs_IND.md)
- - [SubRES_TMPL/SubRES_NewTechs_TRA_Transformation.xlsx](model_structure_docs/SubRES_TMPL_SubRES_NewTechs_TRA_Transformation.md)
- - [SubRES_TMPL/SubRES_NewTechs_TRA_Traditional.xlsx](model_structure_docs/SubRES_TMPL_SubRES_NewTechs_TRA_Traditional.md)
- - [SubRES_TMPL/SubRES_NewTechs_ELC_Traditional.xlsx](model_structure_docs/SubRES_TMPL_SubRES_NewTechs_ELC_Traditional.md)
- - [SubRES_TMPL/SubRES_NewTechs_AGR_Transformation.xlsx](model_structure_docs/SubRES_TMPL_SubRES_NewTechs_AGR_Transformation.md)
- - [SubRES_TMPL/SubRES_NewTechs_ELC_Traditional_trans.xlsx](model_structure_docs/SubRES_TMPL_SubRES_NewTechs_ELC_Traditional_trans.md)
- - [SubRES_TMPL/SubRES_NewTechs_AGR_Traditional.xlsx](model_structure_docs/SubRES_TMPL_SubRES_NewTechs_AGR_Traditional.md)
  - [SubRES_TMPL/SubRES_NewTech_LNG_Imports.xlsx](model_structure_docs/SubRES_TMPL_SubRES_NewTech_LNG_Imports.md)
+ - [SubRES_TMPL/SubRES_NewTechs_AGR_Traditional.xlsx](model_structure_docs/SubRES_TMPL_SubRES_NewTechs_AGR_Traditional.md)
+ - [SubRES_TMPL/SubRES_NewTechs_AGR_Transformation.xlsx](model_structure_docs/SubRES_TMPL_SubRES_NewTechs_AGR_Transformation.md)
+ - [SubRES_TMPL/SubRES_NewTechs_COM.xlsx](model_structure_docs/SubRES_TMPL_SubRES_NewTechs_COM.md)
+ - [SubRES_TMPL/SubRES_NewTechs_ELC_Traditional.xlsx](model_structure_docs/SubRES_TMPL_SubRES_NewTechs_ELC_Traditional.md)
+ - [SubRES_TMPL/SubRES_NewTechs_ELC_Traditional_trans.xlsx](model_structure_docs/SubRES_TMPL_SubRES_NewTechs_ELC_Traditional_trans.md)
+ - [SubRES_TMPL/SubRES_NewTechs_ELC_Transformation.xlsx](model_structure_docs/SubRES_TMPL_SubRES_NewTechs_ELC_Transformation.md)
+ - [SubRES_TMPL/SubRES_NewTechs_ELC_Transformation_trans.xlsx](model_structure_docs/SubRES_TMPL_SubRES_NewTechs_ELC_Transformation_trans.md)
+ - [SubRES_TMPL/SubRES_NewTechs_IND.xlsx](model_structure_docs/SubRES_TMPL_SubRES_NewTechs_IND.md)
+ - [SubRES_TMPL/SubRES_NewTechs_TRA_Traditional.xlsx](model_structure_docs/SubRES_TMPL_SubRES_NewTechs_TRA_Traditional.md)
+ - [SubRES_TMPL/SubRES_NewTechs_TRA_Transformation.xlsx](model_structure_docs/SubRES_TMPL_SubRES_NewTechs_TRA_Transformation.md)
+ - [SubRES_TMPL/SubRES_SectorClosures.xlsx](model_structure_docs/SubRES_TMPL_SubRES_SectorClosures.md)

--- a/docs/model_structure_docs/BY_Trans.md
+++ b/docs/model_structure_docs/BY_Trans.md
@@ -18,5 +18,5 @@ Ensures no investment in selected baseyear techs.
  - Veda Tag: `~TFM_INS`
 
 
- - Data Location: `data_intermediate/stage_4_veda_format/syssettings/banned_techs.csv`
+ - Data Location: `data_intermediate/stage_4_veda_format/sys_settings/banned_techs.csv`
 

--- a/docs/model_structure_docs/SubRES_TMPL_SubRES_NewTech_LNG_Imports.md
+++ b/docs/model_structure_docs/SubRES_TMPL_SubRES_NewTech_LNG_Imports.md
@@ -1,6 +1,16 @@
 [Back to Model Structure Index](../model-structure.md)
 ## SubRES_TMPL/SubRES_NewTech_LNG_Imports.xlsx
 ### WorkSheet: LNG
+**LNGSupplyCommodityDefinitions**: 
+Declare LNG commodity
+
+
+ - Veda Tag: `~FI_Comm`
+
+
+ - Data Location: `VT_TIMESNZ_PRI.toml`
+
+
 **LNGSupplyProcessDefinitions**: 
 Declare LNG production/regasification processes
 
@@ -26,16 +36,6 @@ Defines parameters for different LNG configurations. These are integers, calling
 
 
  - Veda Tag: `~FI_T`
-
-
- - Data Location: `VT_TIMESNZ_PRI.toml`
-
-
-**LNGSupplyCommodityDefinitions**: 
-Declare LNG commodity
-
-
- - Veda Tag: `~FI_Comm`
 
 
  - Data Location: `VT_TIMESNZ_PRI.toml`

--- a/docs/model_structure_docs/SubRES_TMPL_SubRES_NewTechs_COM.md
+++ b/docs/model_structure_docs/SubRES_TMPL_SubRES_NewTechs_COM.md
@@ -1,16 +1,6 @@
 [Back to Model Structure Index](../model-structure.md)
 ## SubRES_TMPL/SubRES_NewTechs_COM.xlsx
 ### WorkSheet: COM_NEW
-**CommercialNewTechParameters**: 
-Defines technical parameters for future commercial technologies
-
-
- - Veda Tag: `~FI_T`
-
-
- - Data Location: `data_intermediate/stage_4_veda_format/subres_com/future_commercial_parameters.csv`
-
-
 **CommercialNewTechProcessDefinitions**: 
 Defines processes for future commercial technologies
 
@@ -19,4 +9,14 @@ Defines processes for future commercial technologies
 
 
  - Data Location: `data_intermediate/stage_4_veda_format/subres_com/future_commercial_processes.csv`
+
+
+**CommercialNewTechParameters**: 
+Defines technical parameters for future commercial technologies
+
+
+ - Veda Tag: `~FI_T`
+
+
+ - Data Location: `data_intermediate/stage_4_veda_format/subres_com/future_commercial_parameters.csv`
 

--- a/docs/model_structure_docs/SubRES_TMPL_SubRES_NewTechs_ELC_Traditional.md
+++ b/docs/model_structure_docs/SubRES_TMPL_SubRES_NewTechs_ELC_Traditional.md
@@ -1,46 +1,5 @@
 [Back to Model Structure Index](../model-structure.md)
 ## SubRES_TMPL/SubRES_NewTechs_ELC_Traditional.xlsx
-### WorkSheet: ELC_GenerationStack
-**GenStackCostCurves**: 
-Standard cost curve projections for applicable genstack plants (Traditional settings)
-
-
- - Veda Tag: `~FI_T`
-
-
- - Data Location: `data_intermediate/stage_4_veda_format/subres_elc/genstack/Traditional_cost_curves.csv`
-
-
-**GenStackCostFixedInstalls**: 
-Defines fixed install dates for genstack plants (Traditional settings)
-
-
- - Veda Tag: `~FI_T`
-
-
- - Data Location: `data_intermediate/stage_4_veda_format/subres_elc/genstack/Traditional_fixed_installs.csv`
-
-
-**GenStackProcesses**: 
-Declares processes for plants from genstack (Traditional settings)
-
-
- - Veda Tag: `~FI_Process`
-
-
- - Data Location: `data_intermediate/stage_4_veda_format/subres_elc/genstack/Traditional_process.csv`
-
-
-**GenStackDetails**: 
-Adds details for new plants from genstack (Traditional settings)
-
-
- - Veda Tag: `~FI_T`
-
-
- - Data Location: `data_intermediate/stage_4_veda_format/subres_elc/genstack/Traditional_parameters.csv`
-
-
 ### WorkSheet: ELC_SolarDist
 **ResidentialSolarProcesses**: 
 Declares processes for new residential rooftop solar
@@ -72,37 +31,6 @@ Conservative cost curve projections for residential rooftop solar (NREL Conserva
  - Data Location: `data_intermediate/stage_4_veda_format/subres_elc/dist_solar/cost_curves_conservative.csv`
 
 
-### WorkSheet: ELC_Batteries
-**BatteryCostCurves**: 
-Adds cost curves to battery technologies
-
-
- - Veda Tag: `~FI_T`
-
-
- - Data Location: `data_intermediate/stage_4_veda_format/subres_elc/storage/battery_costs_traditional.csv`
-
-
-**BatteryProcessDeclarations**: 
-Declares processes for battery technologies
-
-
- - Veda Tag: `~FI_Process`
-
-
- - Data Location: `data_intermediate/stage_4_veda_format/subres_elc/storage/battery_processes.csv`
-
-
-**BatteryParameters**: 
-Describes key assumptions for battery technologies
-
-
- - Veda Tag: `~FI_T`
-
-
- - Data Location: `data_intermediate/stage_4_veda_format/subres_elc/storage/battery_parameters.csv`
-
-
 ### WorkSheet: ELC_OffshoreWind
 **OffshoreWindProcesses**: 
 Declares processes for offshore wind plants
@@ -132,4 +60,76 @@ Standard cost curve projections for offshore wind plants (NREL conservative)
 
 
  - Data Location: `data_intermediate/stage_4_veda_format/subres_elc/offshore/cost_curves_conservative.csv`
+
+
+### WorkSheet: ELC_Batteries
+**BatteryProcessDeclarations**: 
+Declares processes for battery technologies
+
+
+ - Veda Tag: `~FI_Process`
+
+
+ - Data Location: `data_intermediate/stage_4_veda_format/subres_elc/storage/battery_processes.csv`
+
+
+**BatteryParameters**: 
+Describes key assumptions for battery technologies
+
+
+ - Veda Tag: `~FI_T`
+
+
+ - Data Location: `data_intermediate/stage_4_veda_format/subres_elc/storage/battery_parameters.csv`
+
+
+**BatteryCostCurves**: 
+Adds cost curves to battery technologies
+
+
+ - Veda Tag: `~FI_T`
+
+
+ - Data Location: `data_intermediate/stage_4_veda_format/subres_elc/storage/battery_costs_traditional.csv`
+
+
+### WorkSheet: ELC_GenerationStack
+**GenStackProcesses**: 
+Declares processes for plants from genstack (Traditional settings)
+
+
+ - Veda Tag: `~FI_Process`
+
+
+ - Data Location: `data_intermediate/stage_4_veda_format/subres_elc/genstack/Traditional_process.csv`
+
+
+**GenStackDetails**: 
+Adds details for new plants from genstack (Traditional settings)
+
+
+ - Veda Tag: `~FI_T`
+
+
+ - Data Location: `data_intermediate/stage_4_veda_format/subres_elc/genstack/Traditional_parameters.csv`
+
+
+**GenStackCostFixedInstalls**: 
+Defines fixed install dates for genstack plants (Traditional settings)
+
+
+ - Veda Tag: `~FI_T`
+
+
+ - Data Location: `data_intermediate/stage_4_veda_format/subres_elc/genstack/Traditional_fixed_installs.csv`
+
+
+**GenStackCostCurves**: 
+Standard cost curve projections for applicable genstack plants (Traditional settings)
+
+
+ - Veda Tag: `~FI_T`
+
+
+ - Data Location: `data_intermediate/stage_4_veda_format/subres_elc/genstack/Traditional_cost_curves.csv`
 

--- a/docs/model_structure_docs/SubRES_TMPL_SubRES_NewTechs_ELC_Traditional_trans.md
+++ b/docs/model_structure_docs/SubRES_TMPL_SubRES_NewTechs_ELC_Traditional_trans.md
@@ -1,6 +1,26 @@
 [Back to Model Structure Index](../model-structure.md)
 ## SubRES_TMPL/SubRES_NewTechs_ELC_Traditional_trans.xlsx
 ### WorkSheet: AVA
+**ResidentialSolarIslandDefinitions**: 
+Ensure solar plants are available on either island. This is necesssary due to subres transformation usage.
+
+
+ - Veda Tag: `~TFM_AVA`
+
+
+ - Data Location: `data_intermediate/stage_4_veda_format/subres_elc/dist_solar/island_definitions.csv`
+
+
+**OffshoreWindIslandDefinitions**: 
+SubRES Transformation - ensure offshore wind built in correct islands. Idea: test adding this to main subres instead?
+
+
+ - Veda Tag: `~TFM_AVA`
+
+
+ - Data Location: `data_intermediate/stage_4_veda_format/subres_elc/offshore/island_definitions.csv`
+
+
 **BatteryAvailability**: 
 Ensures batteries available on either island
 
@@ -19,24 +39,4 @@ Ensure genstack plants end up in the right island(Traditional settings)
 
 
  - Data Location: `data_intermediate/stage_4_veda_format/subres_elc/genstack/Traditional_island_definitions.csv`
-
-
-**OffshoreWindIslandDefinitions**: 
-SubRES Transformation - ensure offshore wind built in correct islands. Idea: test adding this to main subres instead?
-
-
- - Veda Tag: `~TFM_AVA`
-
-
- - Data Location: `data_intermediate/stage_4_veda_format/subres_elc/offshore/island_definitions.csv`
-
-
-**ResidentialSolarIslandDefinitions**: 
-Ensure solar plants are available on either island. This is necesssary due to subres transformation usage.
-
-
- - Veda Tag: `~TFM_AVA`
-
-
- - Data Location: `data_intermediate/stage_4_veda_format/subres_elc/dist_solar/island_definitions.csv`
 

--- a/docs/model_structure_docs/SubRES_TMPL_SubRES_NewTechs_ELC_Transformation.md
+++ b/docs/model_structure_docs/SubRES_TMPL_SubRES_NewTechs_ELC_Transformation.md
@@ -1,6 +1,16 @@
 [Back to Model Structure Index](../model-structure.md)
 ## SubRES_TMPL/SubRES_NewTechs_ELC_Transformation.xlsx
 ### WorkSheet: ELC_DistSolar
+**ResidentialSolarProcesses**: 
+Declares processes for new residential rooftop solar
+
+
+ - Veda Tag: `~FI_Process`
+
+
+ - Data Location: `data_intermediate/stage_4_veda_format/subres_elc/dist_solar/process_definitions.csv`
+
+
 **ResidentialSolarDetails**: 
 Adds details for residential rooftop solar
 
@@ -21,55 +31,35 @@ Standard cost curve projections for residential rooftop solar (NREL Moderate)
  - Data Location: `data_intermediate/stage_4_veda_format/subres_elc/dist_solar/cost_curves_moderate.csv`
 
 
-**ResidentialSolarProcesses**: 
-Declares processes for new residential rooftop solar
+### WorkSheet: ELC_OffshoreWind
+**OffshoreWindProcesses**: 
+Declares processes for offshore wind plants
 
 
  - Veda Tag: `~FI_Process`
 
 
- - Data Location: `data_intermediate/stage_4_veda_format/subres_elc/dist_solar/process_definitions.csv`
+ - Data Location: `data_intermediate/stage_4_veda_format/subres_elc/offshore/process_definitions.csv`
 
 
-### WorkSheet: ELC_GenerationStack
-**GenStackProcesses**: 
-Declares processes for plants from genstack (Transformation settings)
-
-
- - Veda Tag: `~FI_Process`
-
-
- - Data Location: `data_intermediate/stage_4_veda_format/subres_elc/genstack/Transformation_process.csv`
-
-
-**GenStackDetails**: 
-Adds details for new plants from genstack (Transformation settings)
+**OffshoreWindDetails**: 
+Provides key assumptions for offshore wind plants
 
 
  - Veda Tag: `~FI_T`
 
 
- - Data Location: `data_intermediate/stage_4_veda_format/subres_elc/genstack/Transformation_parameters.csv`
+ - Data Location: `data_intermediate/stage_4_veda_format/subres_elc/offshore/base_file.csv`
 
 
-**GenStackCostCurves**: 
-Standard cost curve projections for applicable genstack plants (Transformation settings)
-
-
- - Veda Tag: `~FI_T`
-
-
- - Data Location: `data_intermediate/stage_4_veda_format/subres_elc/genstack/Transformation_cost_curves.csv`
-
-
-**GenStackCostFixedInstalls**: 
-Defines fixed install dates for genstack plants (Transformation settings)
+**OffshoreWindCostCurves**: 
+Advanced cost curve projections for offshore wind plants (NREL Moderate)
 
 
  - Veda Tag: `~FI_T`
 
 
- - Data Location: `data_intermediate/stage_4_veda_format/subres_elc/genstack/Transformation_fixed_installs.csv`
+ - Data Location: `data_intermediate/stage_4_veda_format/subres_elc/offshore/cost_curves_moderate.csv`
 
 
 ### WorkSheet: ELC_Batteries
@@ -103,33 +93,43 @@ Adds cost curves to battery technologies
  - Data Location: `data_intermediate/stage_4_veda_format/subres_elc/storage/battery_costs_transformation.csv`
 
 
-### WorkSheet: ELC_OffshoreWind
-**OffshoreWindCostCurves**: 
-Advanced cost curve projections for offshore wind plants (NREL Moderate)
-
-
- - Veda Tag: `~FI_T`
-
-
- - Data Location: `data_intermediate/stage_4_veda_format/subres_elc/offshore/cost_curves_moderate.csv`
-
-
-**OffshoreWindDetails**: 
-Provides key assumptions for offshore wind plants
-
-
- - Veda Tag: `~FI_T`
-
-
- - Data Location: `data_intermediate/stage_4_veda_format/subres_elc/offshore/base_file.csv`
-
-
-**OffshoreWindProcesses**: 
-Declares processes for offshore wind plants
+### WorkSheet: ELC_GenerationStack
+**GenStackProcesses**: 
+Declares processes for plants from genstack (Transformation settings)
 
 
  - Veda Tag: `~FI_Process`
 
 
- - Data Location: `data_intermediate/stage_4_veda_format/subres_elc/offshore/process_definitions.csv`
+ - Data Location: `data_intermediate/stage_4_veda_format/subres_elc/genstack/Transformation_process.csv`
+
+
+**GenStackDetails**: 
+Adds details for new plants from genstack (Transformation settings)
+
+
+ - Veda Tag: `~FI_T`
+
+
+ - Data Location: `data_intermediate/stage_4_veda_format/subres_elc/genstack/Transformation_parameters.csv`
+
+
+**GenStackCostFixedInstalls**: 
+Defines fixed install dates for genstack plants (Transformation settings)
+
+
+ - Veda Tag: `~FI_T`
+
+
+ - Data Location: `data_intermediate/stage_4_veda_format/subres_elc/genstack/Transformation_fixed_installs.csv`
+
+
+**GenStackCostCurves**: 
+Standard cost curve projections for applicable genstack plants (Transformation settings)
+
+
+ - Veda Tag: `~FI_T`
+
+
+ - Data Location: `data_intermediate/stage_4_veda_format/subres_elc/genstack/Transformation_cost_curves.csv`
 

--- a/docs/model_structure_docs/SubRES_TMPL_SubRES_NewTechs_ELC_Transformation_trans.md
+++ b/docs/model_structure_docs/SubRES_TMPL_SubRES_NewTechs_ELC_Transformation_trans.md
@@ -1,14 +1,14 @@
 [Back to Model Structure Index](../model-structure.md)
 ## SubRES_TMPL/SubRES_NewTechs_ELC_Transformation_trans.xlsx
 ### WorkSheet: AVA
-**BatteryAvailability**: 
-Ensures batteries available on either island
+**ResidentialSolarIslandDefinitions**: 
+Ensure solar plants are available on either island. This is necesssary due to subres transformation usage
 
 
  - Veda Tag: `~TFM_AVA`
 
 
- - Data Location: `data_intermediate/stage_4_veda_format/subres_elc/storage/battery_availability.csv`
+ - Data Location: `data_intermediate/stage_4_veda_format/subres_elc/dist_solar/island_definitions.csv`
 
 
 **OffshoreWindIslandDefinitions**: 
@@ -21,14 +21,14 @@ SubRES Transformation - ensure offshore wind built in correct islands
  - Data Location: `data_intermediate/stage_4_veda_format/subres_elc/offshore/island_definitions.csv`
 
 
-**ResidentialSolarIslandDefinitions**: 
-Ensure solar plants are available on either island. This is necesssary due to subres transformation usage
+**BatteryAvailability**: 
+Ensures batteries available on either island
 
 
  - Veda Tag: `~TFM_AVA`
 
 
- - Data Location: `data_intermediate/stage_4_veda_format/subres_elc/dist_solar/island_definitions.csv`
+ - Data Location: `data_intermediate/stage_4_veda_format/subres_elc/storage/battery_availability.csv`
 
 
 **GenStackIslandDefinitions**: 

--- a/docs/model_structure_docs/SubRES_TMPL_SubRES_NewTechs_IND.md
+++ b/docs/model_structure_docs/SubRES_TMPL_SubRES_NewTechs_IND.md
@@ -1,16 +1,6 @@
 [Back to Model Structure Index](../model-structure.md)
 ## SubRES_TMPL/SubRES_NewTechs_IND.xlsx
 ### WorkSheet: IND_NEW
-**IndustryNewTechParameters**: 
-Defines technical parameters for future industry technologies
-
-
- - Veda Tag: `~FI_T`
-
-
- - Data Location: `data_intermediate/stage_4_veda_format/subres_ind/future_industry_parameters.csv`
-
-
 **IndustryNewTechProcessDefinitions**: 
 Defines processes for future industry technologies
 
@@ -19,6 +9,16 @@ Defines processes for future industry technologies
 
 
  - Data Location: `data_intermediate/stage_4_veda_format/subres_ind/future_industry_processes.csv`
+
+
+**IndustryNewTechParameters**: 
+Defines technical parameters for future industry technologies
+
+
+ - Veda Tag: `~FI_T`
+
+
+ - Data Location: `data_intermediate/stage_4_veda_format/subres_ind/future_industry_parameters.csv`
 
 
 ### WorkSheet: IND_EAF

--- a/docs/model_structure_docs/SubRES_TMPL_SubRES_NewTechs_TRA_Traditional.md
+++ b/docs/model_structure_docs/SubRES_TMPL_SubRES_NewTechs_TRA_Traditional.md
@@ -1,16 +1,6 @@
 [Back to Model Structure Index](../model-structure.md)
 ## SubRES_TMPL/SubRES_NewTechs_TRA_Traditional.xlsx
 ### WorkSheet: TRA_NEW
-**TransportNewTechParameters**: 
-Defines technical parameters for future transport technologies
-
-
- - Veda Tag: `~FI_T`
-
-
- - Data Location: `data_intermediate/stage_4_veda_format/subres_tra/future_transport_details_standard_costcurve.csv`
-
-
 **TransportNewTechProcessDefinitions**: 
 Defines processes for future transport technologies, using standard cost curves
 
@@ -19,4 +9,14 @@ Defines processes for future transport technologies, using standard cost curves
 
 
  - Data Location: `data_intermediate/stage_4_veda_format/subres_tra/future_transport_processes.csv`
+
+
+**TransportNewTechParameters**: 
+Defines technical parameters for future transport technologies
+
+
+ - Veda Tag: `~FI_T`
+
+
+ - Data Location: `data_intermediate/stage_4_veda_format/subres_tra/future_transport_details_standard_costcurve.csv`
 

--- a/docs/model_structure_docs/SubRES_TMPL_SubRES_NewTechs_TRA_Transformation.md
+++ b/docs/model_structure_docs/SubRES_TMPL_SubRES_NewTechs_TRA_Transformation.md
@@ -1,16 +1,6 @@
 [Back to Model Structure Index](../model-structure.md)
 ## SubRES_TMPL/SubRES_NewTechs_TRA_Transformation.xlsx
 ### WorkSheet: TRA_NEW
-**TransportNewTechParametersAdvanced**: 
-Defines technical parameters for future transport technologies, using advanced cost curves
-
-
- - Veda Tag: `~FI_T`
-
-
- - Data Location: `data_intermediate/stage_4_veda_format/subres_tra/future_transport_details_advanced_costcurve.csv`
-
-
 **TransportNewTechProcessDefinitionsAdvanced**: 
 Defines processes for future transport technologies
 
@@ -19,4 +9,14 @@ Defines processes for future transport technologies
 
 
  - Data Location: `data_intermediate/stage_4_veda_format/subres_tra/future_transport_processes.csv`
+
+
+**TransportNewTechParametersAdvanced**: 
+Defines technical parameters for future transport technologies, using advanced cost curves
+
+
+ - Veda Tag: `~FI_T`
+
+
+ - Data Location: `data_intermediate/stage_4_veda_format/subres_tra/future_transport_details_advanced_costcurve.csv`
 

--- a/docs/model_structure_docs/SubRES_TMPL_SubRES_SectorClosures.md
+++ b/docs/model_structure_docs/SubRES_TMPL_SubRES_SectorClosures.md
@@ -1,16 +1,6 @@
 [Back to Model Structure Index](../model-structure.md)
 ## SubRES_TMPL/SubRES_SectorClosures.xlsx
 ### WorkSheet: SectorClosures
-**SectorClosureParameters**: 
-Sets parameters for sector closures, including costs and possible start dates
-
-
- - Veda Tag: `~FI_T`
-
-
- - Data Location: `data_intermediate/stage_4_veda_format/scen_demand/closure_parameters.csv`
-
-
 **SectorClosureDeclarations**: 
 Declares processes used to close sectors by replacing their need for energy over a certain price point.
 
@@ -19,4 +9,14 @@ Declares processes used to close sectors by replacing their need for energy over
 
 
  - Data Location: `data_intermediate/stage_4_veda_format/scen_demand/closure_declarations.csv`
+
+
+**SectorClosureParameters**: 
+Sets parameters for sector closures, including costs and possible start dates
+
+
+ - Veda Tag: `~FI_T`
+
+
+ - Data Location: `data_intermediate/stage_4_veda_format/scen_demand/closure_parameters.csv`
 

--- a/docs/model_structure_docs/SuppXLS_Demands_Dem_Alloc+Series.md
+++ b/docs/model_structure_docs/SuppXLS_Demands_Dem_Alloc+Series.md
@@ -1,16 +1,5 @@
 [Back to Model Structure Index](../model-structure.md)
 ## SuppXLS/Demands/Dem_Alloc+Series.xlsx
-### WorkSheet: Series
-**HelperSeries**: 
-Provides helper series to support other index methods.
-
-
- - Veda Tag: `~Series`
-
-
- - Data Location: `data_intermediate/stage_4_veda_format/scen_demand/helper_series.csv`
-
-
 ### WorkSheet: DriverAllocation
 **DriverAllocation**: 
 Allocates all commodities to a demand driver. These allocations are the same across all scenarios. The drivers themselves are adjusted.
@@ -20,4 +9,15 @@ Allocates all commodities to a demand driver. These allocations are the same acr
 
 
  - Data Location: `data_intermediate/stage_4_veda_format/scen_demand/driver_allocations.csv`
+
+
+### WorkSheet: Series
+**HelperSeries**: 
+Provides helper series to support other index methods.
+
+
+ - Veda Tag: `~Series`
+
+
+ - Data Location: `data_intermediate/stage_4_veda_format/scen_demand/helper_series.csv`
 

--- a/docs/model_structure_docs/SuppXLS_Scen_Base_Constraints.md
+++ b/docs/model_structure_docs/SuppXLS_Scen_Base_Constraints.md
@@ -1,0 +1,12 @@
+[Back to Model Structure Index](../model-structure.md)
+## SuppXLS/Scen_Base_Constraints.xlsx
+### WorkSheet: VehicleUtilisation
+**VehicleUtilisationConstraints**: 
+Defines the utilisation of each group is at 33% stock.
+
+
+ - Veda Tag: `~UC_T`
+
+
+ - Data Location: `data_raw/coded_assumptions/transport_demand/tra_constraints.csv`
+

--- a/docs/model_structure_docs/SuppXLS_Scen_EAFDemand_Traditional.md
+++ b/docs/model_structure_docs/SuppXLS_Scen_EAFDemand_Traditional.md
@@ -1,16 +1,6 @@
 [Back to Model Structure Index](../model-structure.md)
 ## SuppXLS/Scen_EAFDemand_Traditional.xlsx
 ### WorkSheet: EAF
-**EAFCogenReductionsTraditional**: 
-Traditional scenario EAF cogen output reductions
-
-
- - Veda Tag: `~TFM_INS-TS`
-
-
- - Data Location: `data_intermediate/stage_4_veda_format/scen_demand/eaf/steel_cogen_traditional.csv`
-
-
 **EAFDemandProjectionsTraditional**: 
 Traditional scenario EAF electricity demand projections
 
@@ -19,4 +9,14 @@ Traditional scenario EAF electricity demand projections
 
 
  - Data Location: `data_intermediate/stage_4_veda_format/scen_demand/eaf/eaf_demand_traditional.csv`
+
+
+**EAFCogenReductionsTraditional**: 
+Traditional scenario EAF cogen output reductions
+
+
+ - Veda Tag: `~TFM_INS-TS`
+
+
+ - Data Location: `data_intermediate/stage_4_veda_format/scen_demand/eaf/steel_cogen_traditional.csv`
 

--- a/docs/model_structure_docs/SuppXLS_Scen_LoadCurve_COM-FR.md
+++ b/docs/model_structure_docs/SuppXLS_Scen_LoadCurve_COM-FR.md
@@ -1,14 +1,14 @@
 [Back to Model Structure Index](../model-structure.md)
 ## SuppXLS/Scen_LoadCurve_COM-FR.xlsx
-### WorkSheet: COM
-**LoadCurvesCOMFR_COM**: 
-Defines annual electricity demand timeslices or load curve for commercial sub-sectors
+### WorkSheet: IND
+**LoadCurvesCOMFR_IND**: 
+Defines annual electricity demand timeslices or load curve for industrial sub-sectors
 
 
  - Veda Tag: `~TFM_INS`
 
 
- - Data Location: `data_intermediate/stage_4_veda_format/scen_com_fr/com_fr_commercial.csv`
+ - Data Location: `data_intermediate/stage_4_veda_format/scen_com_fr/com_fr_industry.csv`
 
 
 ### WorkSheet: AGR
@@ -22,6 +22,17 @@ Defines annual electricity demand timeslices or load curve for agriculture sub-s
  - Data Location: `data_intermediate/stage_4_veda_format/scen_com_fr/com_fr_agriculture.csv`
 
 
+### WorkSheet: COM
+**LoadCurvesCOMFR_COM**: 
+Defines annual electricity demand timeslices or load curve for commercial sub-sectors
+
+
+ - Veda Tag: `~TFM_INS`
+
+
+ - Data Location: `data_intermediate/stage_4_veda_format/scen_com_fr/com_fr_commercial.csv`
+
+
 ### WorkSheet: RES
 **LoadCurvesCOMFR_RES**: 
 Defines annual electricity demand timeslices or load curve for residential sub-sectors
@@ -31,15 +42,4 @@ Defines annual electricity demand timeslices or load curve for residential sub-s
 
 
  - Data Location: `data_intermediate/stage_4_veda_format/scen_com_fr/com_fr_residential.csv`
-
-
-### WorkSheet: IND
-**LoadCurvesCOMFR_IND**: 
-Defines annual electricity demand timeslices or load curve for industrial sub-sectors
-
-
- - Veda Tag: `~TFM_INS`
-
-
- - Data Location: `data_intermediate/stage_4_veda_format/scen_com_fr/com_fr_industry.csv`
 

--- a/docs/model_structure_docs/SuppXLS_Scen_WEM_WCM.md
+++ b/docs/model_structure_docs/SuppXLS_Scen_WEM_WCM.md
@@ -1,5 +1,26 @@
 [Back to Model Structure Index](../model-structure.md)
 ## SuppXLS/Scen_WEM_WCM.xlsx
+### WorkSheet: WCM
+**PeakConstraint**: 
+Enables peak constraint (the Winter Capacity Margin/WCM)
+
+
+ - Veda Tag: `~TFM_INS`
+
+
+ - Data Location: `WEM_WCM.toml`
+
+
+**PeakConstraintNIMargin**: 
+Sets 5% NI peak margin
+
+
+ - Veda Tag: `~TFM_INS`
+
+
+ - Data Location: `WEM_WCM.toml`
+
+
 ### WorkSheet: UC_WEM
 **UC_WEM**: 
 User constraint: ensures a national energy margin during winter
@@ -20,25 +41,4 @@ User constraint: ensures a south island energy margin during winter
 
 
  - Data Location: `data_intermediate/stage_3_scenario_data/wem_user_constraints/uc_wem_si.csv`
-
-
-### WorkSheet: WCM
-**PeakConstraint**: 
-Enables peak constraint (the Winter Capacity Margin/WCM)
-
-
- - Veda Tag: `~TFM_INS`
-
-
- - Data Location: `WEM_WCM.toml`
-
-
-**PeakConstraintNIMargin**: 
-Sets 5% NI peak margin
-
-
- - Veda Tag: `~TFM_INS`
-
-
- - Data Location: `WEM_WCM.toml`
 

--- a/docs/model_structure_docs/SuppXLS_Trades_ScenTrade_TRADE_PARMS.md
+++ b/docs/model_structure_docs/SuppXLS_Trades_ScenTrade_TRADE_PARMS.md
@@ -1,16 +1,6 @@
 [Back to Model Structure Index](../model-structure.md)
 ## SuppXLS/Trades/ScenTrade_TRADE_PARMS.xlsx
 ### WorkSheet: Parameters
-**LPGTradeCosts**: 
-Adds transit costs assumptions for other trade processes. Currently these are just from TIMES 2.0 and only includes LPG
-
-
- - Veda Tag: `~TFM_INS`
-
-
- - Data Location: `TradeParameters.toml`
-
-
 **HVDCParameters**: 
 Inserts parameters for HVDC (TB_ELC*) directly from raw input file. Could remove wildcard and change to direct insert?
 
@@ -19,4 +9,14 @@ Inserts parameters for HVDC (TB_ELC*) directly from raw input file. Could remove
 
 
  - Data Location: `data_raw/coded_assumptions/electricity_generation/HVDCAssumptions.csv`
+
+
+**LPGTradeCosts**: 
+Adds transit costs assumptions for other trade processes. Currently these are just from TIMES 2.0 and only includes LPG
+
+
+ - Veda Tag: `~TFM_INS`
+
+
+ - Data Location: `TradeParameters.toml`
 

--- a/docs/model_structure_docs/SysSettings.md
+++ b/docs/model_structure_docs/SysSettings.md
@@ -1,31 +1,21 @@
 [Back to Model Structure Index](../model-structure.md)
 ## SysSettings.xlsx
 ### WorkSheet: SysSettings
-**ActivePDef**: 
-Model Period Definition. Will be used to select period definitions
-
-
- - Veda Tag: `~ActivePDef`
-
-
- - Data Location: `SysSettings.toml`
-
-
-**Currencies**: 
-Default currency unit
-
-
- - Veda Tag: `~Currencies`
-
-
- - Data Location: `SysSettings.toml`
-
-
 **StartYear**: 
 The model base year. Used by several scripts for downstream processing.
 
 
  - Veda Tag: `~StartYear`
+
+
+ - Data Location: `SysSettings.toml`
+
+
+**ActivePDef**: 
+Model Period Definition. Will be used to select period definitions
+
+
+ - Veda Tag: `~ActivePDef`
 
 
  - Data Location: `SysSettings.toml`
@@ -46,6 +36,16 @@ Map books to regions. In the current version, all region information is containe
 
 
  - Veda Tag: `~BookRegions_Map`
+
+
+ - Data Location: `SysSettings.toml`
+
+
+**Currencies**: 
+Default currency unit
+
+
+ - Veda Tag: `~Currencies`
 
 
  - Data Location: `SysSettings.toml`
@@ -93,14 +93,14 @@ Year fractions as calculated based on the number of hours in each slice. Current
 
 
 ### WorkSheet: ImportSettings
-**DisableDummyVariables**: 
-Disables activity of dummy variables. Exclude this table (or change to LO) if you want to solve with infeasibilities.
+**ImportSettings**: 
+Standard Veda control import settings.
 
 
- - Veda Tag: `~TFM_INS`
+ - Veda Tag: `~ImpSettings`
 
 
- - Data Location: `SysSettings.toml`
+ - Data Location: `data_raw/user_config/settings/import_settings.csv`
 
 
 **DummyVariableCosts**: 
@@ -108,6 +108,16 @@ Define costs for generated dummy variables. These should be very high so the mod
 
 
  - Veda Tag: `~TFM_UPD`
+
+
+ - Data Location: `SysSettings.toml`
+
+
+**DisableDummyVariables**: 
+Disables activity of dummy variables. Exclude this table (or change to LO) if you want to solve with infeasibilities.
+
+
+ - Veda Tag: `~TFM_INS`
 
 
  - Data Location: `SysSettings.toml`
@@ -121,14 +131,4 @@ Default interpolation/extrapolation rules. These may need adjusting.
 
 
  - Data Location: `data_raw/user_config/settings/interpolation_extrapolation.csv`
-
-
-**ImportSettings**: 
-Standard Veda control import settings.
-
-
- - Veda Tag: `~ImpSettings`
-
-
- - Data Location: `data_raw/user_config/settings/import_settings.csv`
 

--- a/docs/model_structure_docs/VT_TIMESNZ_AGR.md
+++ b/docs/model_structure_docs/VT_TIMESNZ_AGR.md
@@ -1,66 +1,14 @@
 [Back to Model Structure Index](../model-structure.md)
 ## VT_TIMESNZ_AGR.xlsx
-### WorkSheet: AGR_Emissions
-**AgrEmissionsFactors**: 
-Defines emissions factors for agr fuels
-
-
- - Veda Tag: `~AGREMI`
-
-
- - Data Location: `data_intermediate/stage_4_veda_format/base_year_agr/agr_emission_factors.csv`
-
-
-### WorkSheet: AGR_Demand
-**AgrProcessParameters2**: 
-Summary of agr demand for existing agr technologies by commodity
-
-
- - Veda Tag: `~FI_T: Demand`
-
-
- - Data Location: `data_intermediate/stage_4_veda_format/base_year_agr/agr_baseyear_demand2.csv`
-
-
-**AgrProcessParameters**: 
-Technical parameters for existing agr technologies
-
-
- - Veda Tag: `~FI_T`
-
-
- - Data Location: `data_intermediate/stage_4_veda_format/base_year_agr/agr_baseyear_demand.csv`
-
-
-**AgrProcessDefinitions**: 
-Defines all existing technologies capable for agr demand
-
-
- - Veda Tag: `~FI_Process`
-
-
- - Data Location: `data_intermediate/stage_4_veda_format/base_year_agr/demand_process_definitions.csv`
-
-
-**AgrCommodityDefinitions**: 
-Defines commodities that are in the existing agr sector
+### WorkSheet: AGR_Fuels
+**AgrFuelCommodityDefinitions**: 
+Defines commodities that are used to meet ag, forest, fish demand (eg AGRCOA)
 
 
  - Veda Tag: `~FI_Comm`
 
 
- - Data Location: `data_intermediate/stage_4_veda_format/base_year_agr/enduse_commodity_definitions.csv`
-
-
-### WorkSheet: AGR_Fuels
-**AgrFuelProcessParameters**: 
-Defines technical parameters for dummy agr fuel processes (barely used)
-
-
- - Veda Tag: `~FI_T`
-
-
- - Data Location: `data_intermediate/stage_4_veda_format/base_year_agr/fuel_delivery_parameters.csv`
+ - Data Location: `data_intermediate/stage_4_veda_format/base_year_agr/fuel_commodity_definitions.csv`
 
 
 **AgrFuelProcessDefinitions**: 
@@ -73,12 +21,64 @@ Defines the processes that can convert other TIMES Commodities into these fuels 
  - Data Location: `data_intermediate/stage_4_veda_format/base_year_agr/fuel_delivery_definitions.csv`
 
 
-**AgrFuelCommodityDefinitions**: 
-Defines commodities that are used to meet ag, forest, fish demand (eg AGRCOA)
+**AgrFuelProcessParameters**: 
+Defines technical parameters for dummy agr fuel processes (barely used)
+
+
+ - Veda Tag: `~FI_T`
+
+
+ - Data Location: `data_intermediate/stage_4_veda_format/base_year_agr/fuel_delivery_parameters.csv`
+
+
+### WorkSheet: AGR_Demand
+**AgrCommodityDefinitions**: 
+Defines commodities that are in the existing agr sector
 
 
  - Veda Tag: `~FI_Comm`
 
 
- - Data Location: `data_intermediate/stage_4_veda_format/base_year_agr/fuel_commodity_definitions.csv`
+ - Data Location: `data_intermediate/stage_4_veda_format/base_year_agr/enduse_commodity_definitions.csv`
+
+
+**AgrProcessDefinitions**: 
+Defines all existing technologies capable for agr demand
+
+
+ - Veda Tag: `~FI_Process`
+
+
+ - Data Location: `data_intermediate/stage_4_veda_format/base_year_agr/demand_process_definitions.csv`
+
+
+**AgrProcessParameters**: 
+Technical parameters for existing agr technologies
+
+
+ - Veda Tag: `~FI_T`
+
+
+ - Data Location: `data_intermediate/stage_4_veda_format/base_year_agr/agr_baseyear_demand.csv`
+
+
+**AgrProcessParameters2**: 
+Summary of agr demand for existing agr technologies by commodity
+
+
+ - Veda Tag: `~FI_T: Demand`
+
+
+ - Data Location: `data_intermediate/stage_4_veda_format/base_year_agr/agr_baseyear_demand2.csv`
+
+
+### WorkSheet: AGR_Emissions
+**AgrEmissionsFactors**: 
+Defines emissions factors for agr fuels
+
+
+ - Veda Tag: `~AGREMI`
+
+
+ - Data Location: `data_intermediate/stage_4_veda_format/base_year_agr/agr_emission_factors.csv`
 

--- a/docs/model_structure_docs/VT_TIMESNZ_COM.md
+++ b/docs/model_structure_docs/VT_TIMESNZ_COM.md
@@ -1,25 +1,14 @@
 [Back to Model Structure Index](../model-structure.md)
 ## VT_TIMESNZ_COM.xlsx
-### WorkSheet: COM_Emissions
-**CommercialEmissionsFactors**: 
-Defines emissions factors for commercial fuels
-
-
- - Veda Tag: `~COMEMI`
-
-
- - Data Location: `data_intermediate/stage_4_veda_format/base_year_com/commercial_emission_factors.csv`
-
-
 ### WorkSheet: COM_Fuels
-**CommercialFuelProcessParameters**: 
-Defines technical parameters for dummy commercial fuel processes (barely used)
+**CommercialFuelCommodityDefinitions**: 
+Defines commodities that are used to meet commercial demand (eg COMCOA)
 
 
- - Veda Tag: `~FI_T`
+ - Veda Tag: `~FI_Comm`
 
 
- - Data Location: `data_intermediate/stage_4_veda_format/base_year_com/fuel_delivery_parameters.csv`
+ - Data Location: `data_intermediate/stage_4_veda_format/base_year_com/fuel_commodity_definitions.csv`
 
 
 **CommercialFuelProcessDefinitions**: 
@@ -32,14 +21,14 @@ Defines the processes that can convert other TIMES Commodities into these fuels 
  - Data Location: `data_intermediate/stage_4_veda_format/base_year_com/fuel_delivery_definitions.csv`
 
 
-**CommercialFuelCommodityDefinitions**: 
-Defines commodities that are used to meet commercial demand (eg COMCOA)
+**CommercialFuelProcessParameters**: 
+Defines technical parameters for dummy commercial fuel processes (barely used)
 
 
- - Veda Tag: `~FI_Comm`
+ - Veda Tag: `~FI_T`
 
 
- - Data Location: `data_intermediate/stage_4_veda_format/base_year_com/fuel_commodity_definitions.csv`
+ - Data Location: `data_intermediate/stage_4_veda_format/base_year_com/fuel_delivery_parameters.csv`
 
 
 ### WorkSheet: COM_Demand
@@ -81,4 +70,15 @@ Summary of commercial demand for existing commercial technologies by commodity
 
 
  - Data Location: `data_intermediate/stage_4_veda_format/base_year_com/commercial_baseyear_demand2.csv`
+
+
+### WorkSheet: COM_Emissions
+**CommercialEmissionsFactors**: 
+Defines emissions factors for commercial fuels
+
+
+ - Veda Tag: `~COMEMI`
+
+
+ - Data Location: `data_intermediate/stage_4_veda_format/base_year_com/commercial_emission_factors.csv`
 

--- a/docs/model_structure_docs/VT_TIMESNZ_ELC.md
+++ b/docs/model_structure_docs/VT_TIMESNZ_ELC.md
@@ -1,47 +1,37 @@
 [Back to Model Structure Index](../model-structure.md)
 ## VT_TIMESNZ_ELC.xlsx
-### WorkSheet: Distribution
-**DistributionProcessParameters**: 
-Sets technical parameters for distribution processes (eg losses, capacity, etc)
-
-
- - Veda Tag: `~FI_T`
-
-
- - Data Location: `data_intermediate/stage_4_veda_format/base_year_elc/distribution_parameters.csv`
-
-
-**DitributionCommodityDefinitions**: 
-Defines electricity distribution subprocessses (eg ELCHV, ELCMV, ELCDD)
+### WorkSheet: Sector_Fuels_ELC
+**ElectricityFuelCommodityDefinitions**: 
+Defines commodities that can be used for electricity generation (eg ELCNGA)
 
 
  - Veda Tag: `~FI_Comm`
 
 
- - Data Location: `data_intermediate/stage_4_veda_format/base_year_elc/distribution_commodities.csv`
+ - Data Location: `data_intermediate/stage_4_veda_format/base_year_elc/elc_input_commodity_definitions.csv`
 
 
-**DistributionProcessDefinitions**: 
-Defines all processes involved in distribution (eg Processes that convert ELC to ELCHV)
+**ElectricityFuelProcessDefinitions**: 
+Defines the processes that can convert other TIMES Commodities into these fuels (eg NGA -> ELCNGA)
 
 
  - Veda Tag: `~FI_Process`
 
 
- - Data Location: `data_intermediate/stage_4_veda_format/base_year_elc/distribution_processes.csv`
+ - Data Location: `data_intermediate/stage_4_veda_format/base_year_elc/elc_dummy_fuel_process_definitions.csv`
 
 
-### WorkSheet: Existing Technologies
-**ElectricityProcessParameters**: 
-Technical parameters for existing electricity generation technologies
+**ElectricityFuelProcessParameters**: 
+Defines technical parameters for dummy electricity fuel processes (barely used)
 
 
  - Veda Tag: `~FI_T`
 
 
- - Data Location: `data_intermediate/stage_4_veda_format/base_year_elc/existing_tech_parameters.csv`
+ - Data Location: `data_intermediate/stage_4_veda_format/base_year_elc/elc_dummy_fuel_process_parameters.csv`
 
 
+### WorkSheet: Existing Technologies
 **JustDefiningElectricity**: 
 Defines ELC and ELCCO2 (should these just be added to [ElectricityCommodityDefinitions]?)
 
@@ -62,14 +52,14 @@ Defines all existing technologies capable of generating electricity
  - Data Location: `data_intermediate/stage_4_veda_format/base_year_elc/existing_tech_process_definitions.csv`
 
 
-**ElectricityProcessSpecificCapacityFactors**: 
-Locking specific capacity factors for plants where we have precise data, to ensure alignment.
+**ElectricityProcessParameters**: 
+Technical parameters for existing electricity generation technologies
 
 
  - Veda Tag: `~FI_T`
 
 
- - Data Location: `data_intermediate/stage_4_veda_format/base_year_elc/base_year_capacity_factors.csv`
+ - Data Location: `data_intermediate/stage_4_veda_format/base_year_elc/existing_tech_parameters.csv`
 
 
 **ElectricityProcessAgeDistributions**: 
@@ -80,6 +70,47 @@ Adds age distributions for each plant or plant type (either NCAP_PASTI when life
 
 
  - Data Location: `data_intermediate/stage_4_veda_format/base_year_elc/existing_tech_capacity.csv`
+
+
+**ElectricityProcessSpecificCapacityFactors**: 
+Locking specific capacity factors for plants where we have precise data, to ensure alignment.
+
+
+ - Veda Tag: `~FI_T`
+
+
+ - Data Location: `data_intermediate/stage_4_veda_format/base_year_elc/base_year_capacity_factors.csv`
+
+
+### WorkSheet: Distribution
+**DistributionProcessDefinitions**: 
+Defines all processes involved in distribution (eg Processes that convert ELC to ELCHV)
+
+
+ - Veda Tag: `~FI_Process`
+
+
+ - Data Location: `data_intermediate/stage_4_veda_format/base_year_elc/distribution_processes.csv`
+
+
+**DitributionCommodityDefinitions**: 
+Defines electricity distribution subprocessses (eg ELCHV, ELCMV, ELCDD)
+
+
+ - Veda Tag: `~FI_Comm`
+
+
+ - Data Location: `data_intermediate/stage_4_veda_format/base_year_elc/distribution_commodities.csv`
+
+
+**DistributionProcessParameters**: 
+Sets technical parameters for distribution processes (eg losses, capacity, etc)
+
+
+ - Veda Tag: `~FI_T`
+
+
+ - Data Location: `data_intermediate/stage_4_veda_format/base_year_elc/distribution_parameters.csv`
 
 
 ### WorkSheet: Emission Factors
@@ -111,35 +142,4 @@ Manual adjustments to reduce Ngawha emissions to 0 by 2026. Note these are hardc
 
 
  - Data Location: `VT_TIMESNZ_ELC.toml`
-
-
-### WorkSheet: Sector_Fuels_ELC
-**ElectricityFuelCommodityDefinitions**: 
-Defines commodities that can be used for electricity generation (eg ELCNGA)
-
-
- - Veda Tag: `~FI_Comm`
-
-
- - Data Location: `data_intermediate/stage_4_veda_format/base_year_elc/elc_input_commodity_definitions.csv`
-
-
-**ElectricityFuelProcessParameters**: 
-Defines technical parameters for dummy electricity fuel processes (barely used)
-
-
- - Veda Tag: `~FI_T`
-
-
- - Data Location: `data_intermediate/stage_4_veda_format/base_year_elc/elc_dummy_fuel_process_parameters.csv`
-
-
-**ElectricityFuelProcessDefinitions**: 
-Defines the processes that can convert other TIMES Commodities into these fuels (eg NGA -> ELCNGA)
-
-
- - Veda Tag: `~FI_Process`
-
-
- - Data Location: `data_intermediate/stage_4_veda_format/base_year_elc/elc_dummy_fuel_process_definitions.csv`
 

--- a/docs/model_structure_docs/VT_TIMESNZ_IND.md
+++ b/docs/model_structure_docs/VT_TIMESNZ_IND.md
@@ -73,21 +73,21 @@ Sets parameters for industry fuel delivery processes (mostly delivery costs)
 
 
 ### WorkSheet: Emissions
-**IndustryEmissionsParameters**: 
-Defines emissions factors for industry fuels. Currently hardcoded and need a proper update. To do with all other demand emission factors for consistency
-
-
- - Veda Tag: `~COMEMI`
-
-
- - Data Location: `VT_TIMESNZ_IND.toml`
-
-
 **IndustryEmissionsDefinitions**: 
 Defines the industry emissions commodity
 
 
  - Veda Tag: `~FI_Comm`
+
+
+ - Data Location: `VT_TIMESNZ_IND.toml`
+
+
+**IndustryEmissionsParameters**: 
+Defines emissions factors for industry fuels. Currently hardcoded and need a proper update. To do with all other demand emission factors for consistency
+
+
+ - Veda Tag: `~COMEMI`
 
 
  - Data Location: `VT_TIMESNZ_IND.toml`

--- a/docs/model_structure_docs/VT_TIMESNZ_PRI.md
+++ b/docs/model_structure_docs/VT_TIMESNZ_PRI.md
@@ -1,18 +1,8 @@
 [Back to Model Structure Index](../model-structure.md)
 ## VT_TIMESNZ_PRI.xlsx
-### WorkSheet: Total CO2
-**TOTCO2AggregationDefinition**: 
-Defines TOTCO2 as the sum of all other emissions commodities. No refinery.
-
-
- - Veda Tag: `~COMAGG`
-
-
- - Data Location: `VT_TIMESNZ_PRI.toml`
-
-
-**TOTCO2CommodityDefinition**: 
-Declares TOTCO2 commodity. In old TIMES, all other emissions were re-declared here (not necessary)
+### WorkSheet: Natural Gas
+**GasSupplyCommodityDefinitions**: 
+Declare natural gas and fugitive emissions commodities (North Island only). Hardcoded in user config.
 
 
  - Veda Tag: `~FI_Comm`
@@ -21,9 +11,8 @@ Declares TOTCO2 commodity. In old TIMES, all other emissions were re-declared he
  - Data Location: `VT_TIMESNZ_PRI.toml`
 
 
-### WorkSheet: Coal
-**CoalProcessDeclarations**: 
-Declare coal processes (mining and importing)
+**GasSupplyProcessDefinitions**: 
+Declare natural gas production processes
 
 
  - Veda Tag: `~FI_Process`
@@ -32,8 +21,29 @@ Declare coal processes (mining and importing)
  - Data Location: `VT_TIMESNZ_PRI.toml`
 
 
-**CoalCommodityDeclarations**: 
-Declare coal commodity
+**GasSupplyParameters**: 
+Production costs and fugitive emissions for domestic gas fields, and output commodity declaration.
+
+
+ - Veda Tag: `~FI_T`
+
+
+ - Data Location: `data_intermediate/stage_4_veda_format/base_year_pri/natural_gas_production_parameters.csv`
+
+
+**GasSupplyForecasts**: 
+Add natural gas production forecast limits. Excludes contingent - only the 2P reserves.
+
+
+ - Veda Tag: `~FI_T`
+
+
+ - Data Location: `data_intermediate/stage_4_veda_format/base_year_pri/deliverability_forecasts_2p.csv`
+
+
+### WorkSheet: Oil
+**OilSupplyCommodityDefinitions**: 
+Define Oil and oil product commodities
 
 
  - Veda Tag: `~FI_Comm`
@@ -42,17 +52,6 @@ Declare coal commodity
  - Data Location: `VT_TIMESNZ_PRI.toml`
 
 
-**CoalParameterDeclarations**: 
-Declare coal processes (mining and importing). Sets coal price (sans carbon) and annual availability . Very simple approach
-
-
- - Veda Tag: `~FI_T`
-
-
- - Data Location: `VT_TIMESNZ_PRI.toml`
-
-
-### WorkSheet: Oil
 **OilProcessDeclarations**: 
 Declare oil and oil product supply processes (mining, imports). Include exports
 
@@ -73,8 +72,9 @@ Set base year activity and cost assumptions for oil product imports. Note extrem
  - Data Location: `data_intermediate/stage_4_veda_format/base_year_pri/imported_fuel_costs.csv`
 
 
-**OilSupplyCommodityDefinitions**: 
-Define Oil and oil product commodities
+### WorkSheet: Coal
+**CoalCommodityDeclarations**: 
+Declare coal commodity
 
 
  - Veda Tag: `~FI_Comm`
@@ -83,15 +83,56 @@ Define Oil and oil product commodities
  - Data Location: `VT_TIMESNZ_PRI.toml`
 
 
-### WorkSheet: Biofuels
-**BiofuelSupplyForecasts**: 
-Biomass/biofuel supply and costs forecasts per region 
+**CoalProcessDeclarations**: 
+Declare coal processes (mining and importing)
+
+
+ - Veda Tag: `~FI_Process`
+
+
+ - Data Location: `VT_TIMESNZ_PRI.toml`
+
+
+**CoalParameterDeclarations**: 
+Declare coal processes (mining and importing). Sets coal price (sans carbon) and annual availability . Very simple approach
 
 
  - Veda Tag: `~FI_T`
 
 
- - Data Location: `data_intermediate/stage_4_veda_format/base_year_pri/biofuel_supply_forecasts.csv`
+ - Data Location: `VT_TIMESNZ_PRI.toml`
+
+
+### WorkSheet: Total CO2
+**TOTCO2CommodityDefinition**: 
+Declares TOTCO2 commodity. In old TIMES, all other emissions were re-declared here (not necessary)
+
+
+ - Veda Tag: `~FI_Comm`
+
+
+ - Data Location: `VT_TIMESNZ_PRI.toml`
+
+
+**TOTCO2AggregationDefinition**: 
+Defines TOTCO2 as the sum of all other emissions commodities. No refinery.
+
+
+ - Veda Tag: `~COMAGG`
+
+
+ - Data Location: `VT_TIMESNZ_PRI.toml`
+
+
+### WorkSheet: Biofuels
+**DeclareBiofuels**: 
+Declare biofuel energy commodities
+
+
+ - Veda Tag: `~FI_Comm`
+
+
+ - Data Location: `VT_TIMESNZ_PRI.toml`
 
 
 **BiofuelProcessDeclarations**: 
@@ -104,6 +145,16 @@ Declare biomass/biofuel processes, including raw production and transformation
  - Data Location: `data_intermediate/stage_4_veda_format/base_year_pri/biofuel_supply_process_declarations.csv`
 
 
+**BiofuelSupplyForecasts**: 
+Biomass/biofuel supply and costs forecasts per region 
+
+
+ - Veda Tag: `~FI_T`
+
+
+ - Data Location: `data_intermediate/stage_4_veda_format/base_year_pri/biofuel_supply_forecasts.csv`
+
+
 **BiofuelParameterDeclarations**: 
 Declare conversion processes for biofuel. Sets investment and operation costs, annual availability, lifetime
 
@@ -114,58 +165,17 @@ Declare conversion processes for biofuel. Sets investment and operation costs, a
  - Data Location: `data_raw/coded_assumptions/biofuels/plant_processes.csv`
 
 
-**DeclareBiofuels**: 
-Declare biofuel energy commodities
-
-
- - Veda Tag: `~FI_Comm`
-
-
- - Data Location: `VT_TIMESNZ_PRI.toml`
-
-
-### WorkSheet: Natural Gas
-**GasSupplyForecasts**: 
-Add natural gas production forecast limits. Excludes contingent - only the 2P reserves.
-
-
- - Veda Tag: `~FI_T`
-
-
- - Data Location: `data_intermediate/stage_4_veda_format/base_year_pri/deliverability_forecasts_2p.csv`
-
-
-**GasSupplyParameters**: 
-Production costs and fugitive emissions for domestic gas fields, and output commodity declaration.
-
-
- - Veda Tag: `~FI_T`
-
-
- - Data Location: `data_intermediate/stage_4_veda_format/base_year_pri/natural_gas_production_parameters.csv`
-
-
-**GasSupplyProcessDefinitions**: 
-Declare natural gas production processes
-
-
- - Veda Tag: `~FI_Process`
-
-
- - Data Location: `VT_TIMESNZ_PRI.toml`
-
-
-**GasSupplyCommodityDefinitions**: 
-Declare natural gas and fugitive emissions commodities (North Island only). Hardcoded in user config.
-
-
- - Veda Tag: `~FI_Comm`
-
-
- - Data Location: `VT_TIMESNZ_PRI.toml`
-
-
 ### WorkSheet: Hydrogen
+**DeclareHydrogenCommodity**: 
+Hydrogen commodity
+
+
+ - Veda Tag: `~FI_Comm`
+
+
+ - Data Location: `VT_TIMESNZ_PRI.toml`
+
+
 **HydrogenProcessDeclarations**: 
 Declare hydrogen production placeholder. We need to later build actual electrolysis.
 
@@ -181,16 +191,6 @@ Placeholder hydrogen production process, just to ensure the model doesn't get fr
 
 
  - Veda Tag: `~FI_T`
-
-
- - Data Location: `VT_TIMESNZ_PRI.toml`
-
-
-**DeclareHydrogenCommodity**: 
-Hydrogen commodity
-
-
- - Veda Tag: `~FI_Comm`
 
 
  - Data Location: `VT_TIMESNZ_PRI.toml`

--- a/docs/model_structure_docs/VT_TIMESNZ_RES.md
+++ b/docs/model_structure_docs/VT_TIMESNZ_RES.md
@@ -21,6 +21,16 @@ Defines residential input fuel commodities, such as electricity (RESELC)
  - Data Location: `data_intermediate/stage_4_veda_format/base_year_res/fuel_commodity_definitions.csv`
 
 
+**ResidentialProcessDefinitions**: 
+Defines residential enduse processes, such as heatpumps
+
+
+ - Veda Tag: `~FI_Process`
+
+
+ - Data Location: `data_intermediate/stage_4_veda_format/base_year_res/demand_process_definitions.csv`
+
+
 **ResidentialDemand**: 
 Residential base year demand topology and technical parameters
 
@@ -41,27 +51,7 @@ Residential total commodity demand (met by activity bound per process)
  - Data Location: `data_intermediate/stage_4_veda_format/base_year_res/residential_commodity_demand.csv`
 
 
-**ResidentialProcessDefinitions**: 
-Defines residential enduse processes, such as heatpumps
-
-
- - Veda Tag: `~FI_Process`
-
-
- - Data Location: `data_intermediate/stage_4_veda_format/base_year_res/demand_process_definitions.csv`
-
-
 ### WorkSheet: Fuel Delivery
-**ResidentialFuelProcessParameters**: 
-Sets parameters for residential fuel delivery processes (mostly delivery costs)
-
-
- - Veda Tag: `~FI_T`
-
-
- - Data Location: `data_intermediate/stage_4_veda_format/base_year_res/fuel_delivery_parameters.csv`
-
-
 **ResidentialFuelProcessDefinitions**: 
 Defines residential fuel delivery processes that convert fuels (like NGA) into RES fuels (INDNGA)
 
@@ -72,22 +62,32 @@ Defines residential fuel delivery processes that convert fuels (like NGA) into R
  - Data Location: `data_intermediate/stage_4_veda_format/base_year_res/fuel_delivery_definitions.csv`
 
 
+**ResidentialFuelProcessParameters**: 
+Sets parameters for residential fuel delivery processes (mostly delivery costs)
+
+
+ - Veda Tag: `~FI_T`
+
+
+ - Data Location: `data_intermediate/stage_4_veda_format/base_year_res/fuel_delivery_parameters.csv`
+
+
 ### WorkSheet: Emissions
-**ResidentialEmissionsParameters**: 
-Defines emissions factors for residential fuels. Currently hardcoded and need a proper update. To do with all other demand emission factors for consistency
-
-
- - Veda Tag: `~COMEMI`
-
-
- - Data Location: `VT_TIMESNZ_RES.toml`
-
-
 **ResidentialEmissionsDefinitions**: 
 Defines the residential emissions commodity
 
 
  - Veda Tag: `~FI_Comm`
+
+
+ - Data Location: `VT_TIMESNZ_RES.toml`
+
+
+**ResidentialEmissionsParameters**: 
+Defines emissions factors for residential fuels. Currently hardcoded and need a proper update. To do with all other demand emission factors for consistency
+
+
+ - Veda Tag: `~COMEMI`
 
 
  - Data Location: `VT_TIMESNZ_RES.toml`

--- a/docs/model_structure_docs/VT_TIMESNZ_TRA.md
+++ b/docs/model_structure_docs/VT_TIMESNZ_TRA.md
@@ -1,16 +1,6 @@
 [Back to Model Structure Index](../model-structure.md)
 ## VT_TIMESNZ_TRA.xlsx
 ### WorkSheet: TRA_FuelSupply
-**TransportFuelProcessDefinitions**: 
-Defines the processes that can convert other TIMES Commodities into these fuels (eg PET -> TRAPET)
-
-
- - Veda Tag: `~FI_Process`
-
-
- - Data Location: `data_intermediate/stage_4_veda_format/base_year_tra/tra_fuel_process_definitions.csv`
-
-
 **TransportFuelCommodityDefinitions**: 
 Defines commodities that are used to meet transport demand (eg TRAPET)
 
@@ -19,6 +9,16 @@ Defines commodities that are used to meet transport demand (eg TRAPET)
 
 
  - Data Location: `data_intermediate/stage_4_veda_format/base_year_tra/tra_fuel_commodity_definitions.csv`
+
+
+**TransportFuelProcessDefinitions**: 
+Defines the processes that can convert other TIMES Commodities into these fuels (eg PET -> TRAPET)
+
+
+ - Veda Tag: `~FI_Process`
+
+
+ - Data Location: `data_intermediate/stage_4_veda_format/base_year_tra/tra_fuel_process_definitions.csv`
 
 
 **TransportFuelProcessParameters**: 
@@ -31,38 +31,7 @@ Defines technical parameters for dummy transport fuel processes (barely used)
  - Data Location: `data_intermediate/stage_4_veda_format/base_year_tra/tra_fuel_process_parameters.csv`
 
 
-### WorkSheet: TRA_Emissions
-**TransportEmissionsFactors**: 
-Defines emissions factors for transport fuels. Sources and references listed in config file. Excludes CH4 and N2O.
-
-
- - Veda Tag: `~COMEMI`
-
-
- - Data Location: `data_intermediate/stage_4_veda_format/base_year_tra/tra_emission_factors.csv`
-
-
 ### WorkSheet: TRA_Demand-Vehicles
-**TransportProcessParameters2**: 
-Summary of transport demand for existing transport technologies by commodity
-
-
- - Veda Tag: `~FI_T: Demand`
-
-
- - Data Location: `data_intermediate/stage_4_veda_format/base_year_tra/tra_process_parameters2.csv`
-
-
-**TransportProcessParameters**: 
-Technical parameters for existing transport technologies
-
-
- - Veda Tag: `~FI_T`
-
-
- - Data Location: `data_intermediate/stage_4_veda_format/base_year_tra/tra_process_parameters.csv`
-
-
 **TransportCommodityDefinitions**: 
 Defines commodities that are in the existing transport fleet
 
@@ -81,4 +50,35 @@ Defines all existing technologies capable for transport demand
 
 
  - Data Location: `data_intermediate/stage_4_veda_format/base_year_tra/tra_process_definitions.csv`
+
+
+**TransportProcessParameters**: 
+Technical parameters for existing transport technologies
+
+
+ - Veda Tag: `~FI_T`
+
+
+ - Data Location: `data_intermediate/stage_4_veda_format/base_year_tra/tra_process_parameters.csv`
+
+
+**TransportProcessParameters2**: 
+Summary of transport demand for existing transport technologies by commodity
+
+
+ - Veda Tag: `~FI_T: Demand`
+
+
+ - Data Location: `data_intermediate/stage_4_veda_format/base_year_tra/tra_process_parameters2.csv`
+
+
+### WorkSheet: TRA_Emissions
+**TransportEmissionsFactors**: 
+Defines emissions factors for transport fuels. Sources and references listed in config file. Excludes CH4 and N2O.
+
+
+ - Veda Tag: `~COMEMI`
+
+
+ - Data Location: `data_intermediate/stage_4_veda_format/base_year_tra/tra_emission_factors.csv`
 


### PR DESCRIPTION
Very minor change which should stop the random reordering of the auto-generated documentation by fixing the workbook order 

Had to regenerate them all again but now they should only update when we actually change toml files, which is the intent. 


