### PR TITLE
Lng update

### DIFF
--- a/PREPARE-TIMES-NZ/data_raw/user_config/new_technologies/NewTech_LNG_Traditional.toml
+++ b/PREPARE-TIMES-NZ/data_raw/user_config/new_technologies/NewTech_LNG_Traditional.toml
@@ -1,0 +1,73 @@
+###########################################
+# LNG subres
+###########################################
+
+
+WorkBookName = "SubRES_TMPL/SubRES_LNG_Imports_Traditional"
+
+[LNGSupplyCommodityDefinitions]
+Description = "Declare LNG commodity"
+SheetName = "LNG"
+TagName = "FI_Comm"
+Csets = ["NRG"]
+Region = ["NI"]
+CommName = ["LNG"]
+Unit = ["PJ"]
+
+
+[LNGSupplyProcessDefinitions]
+Description = "Declare LNG production/regasification processes"
+SheetName = "LNG"
+TagName = "FI_Process"
+Sets = ["IMP", "PRE"] 
+TechName = ["IMPLNG", # just import the commodity            
+            "LNGPORTSTD" # standard configuration (small possible but not currently included)
+            ]
+Tact = "PJ"
+Tcap = ["PJa", "StandardPort"] # we are defining abstract units for these ports to work around
+
+[LNGCommodityCosts]
+Description = "Defines costs for LNG import (Just the commodity, not infrastructure or delivery)"
+SheetName = "LNG"
+TagName = "FI_T"
+TechName = "IMPLNG"
+Comm-IN = ""
+Comm-OUT = "LNG"
+COST = 20
+
+[LNGImportConfigurations]
+Description = "Defines parameters for different LNG configurations"
+SheetName = "LNG"
+TagName = "FI_T"           
+
+[LNGImportConfigurations.Data]
+TechName = ["LNGPORTSTD"]
+Comm-IN = ["LNG"]
+Comm-OUT = ["NGA"]
+INVCOST = [800] # again, this is total per "port" unit. We can only build one port unit, and this is the price NZDm
+CAP2ACT = [40] # ie, the small port can produce 9 a year, and the big port 40: now all our capacity unit is "port" so everything simpler 
+Eff = [1] # this is by default anyway, but we'll make explicit
+AFA = [1] # defaults, but explicit - can run at max capacity 
+"AFA~LO" = [0] # force the small port to always run at max capacity, as per the reporting on these setups. You buy LNG ahead of time and must deliver. 
+FIXOM = [90] # operating costs per capacity unit (NZDm per port setup excl capex) 
+
+# Lock to NI by creating a trans file 
+
+[LNGImportNIOnly]
+WorkBookName = "SubRES_TMPL/SubRES_LNG_Imports_Traditional_trans"
+Description = "Locks LNG processes to NI"
+SheetName = "AVA"
+TagName = "TFM_AVA"       
+Pset_PN = ["LNGPORTSTD", "IMPLNG"]
+SI = [0,0]
+NI = [1,1]
+
+
+# Scenario file for build timing
+[LNGImportBuildOptions]
+WorkBookName = "SuppXLS/Scen_LNG_build_timing_Traditional"
+Description = "Build timing for LNG port, including single port unit build at 2027."
+SheetName = "LNG"
+TagName = "TFM_INS"
+DataLocation = "data_raw/coded_assumptions/oil_and_gas/lng_build_timing.csv"
+

--- a/PREPARE-TIMES-NZ/data_raw/user_config/new_technologies/NewTech_LNG_Transformation.toml
+++ b/PREPARE-TIMES-NZ/data_raw/user_config/new_technologies/NewTech_LNG_Transformation.toml
@@ -1,11 +1,9 @@
 ###########################################
 # LNG subres
-# we include a scenario file for investment timing - you'd also use this if you wanted to set lumpy investment
-# kept in this config file for tidiness (it's small) 
 ###########################################
 
 
-WorkBookName = "SubRES_TMPL/SubRES_NewTech_LNG_Imports"
+WorkBookName = "SubRES_TMPL/SubRES_LNG_Imports_Transformation"
 
 [LNGSupplyCommodityDefinitions]
 Description = "Declare LNG commodity"
@@ -35,7 +33,7 @@ TagName = "FI_T"
 TechName = "IMPLNG"
 Comm-IN = ""
 Comm-OUT = "LNG"
-COST = 18 # NZD/GJ
+COST = 40
 
 [LNGImportConfigurations]
 Description = "Defines parameters for different LNG configurations"
@@ -56,7 +54,7 @@ FIXOM = [90] # operating costs per capacity unit (NZDm per port setup excl capex
 # Lock to NI by creating a trans file 
 
 [LNGImportNIOnly]
-WorkBookName = "SubRES_TMPL/SubRES_NewTech_LNG_Imports_trans"
+WorkBookName = "SubRES_TMPL/SubRES_LNG_Imports_Transformation_trans"
 Description = "Locks LNG processes to NI"
 SheetName = "AVA"
 TagName = "TFM_AVA"       
@@ -67,7 +65,7 @@ NI = [1,1]
 
 # Scenario file for build timing
 [LNGImportBuildOptions]
-WorkBookName = "SuppXLS/Scen_LNG_build_timing"
+WorkBookName = "SuppXLS/Scen_LNG_build_timing_Transformation"
 Description = "Build timing for LNG port, including single port unit build at 2027."
 SheetName = "LNG"
 TagName = "TFM_INS"

--- a/PREPARE-TIMES-NZ/docs/source/model_methodology/oil_gas/imported_lng.md
+++ b/PREPARE-TIMES-NZ/docs/source/model_methodology/oil_gas/imported_lng.md
@@ -51,15 +51,20 @@ Variable,Standard terminal
 Annual maximum output,Unlimited[^import_limits]
 Capital cost NZDm,794
 Operating cost NZDm pa,95
-LNG commodity cost NZD/GJ,18
+LNG commodity cost NZD/GJ,20
 Installation date, 2027
 ```
 
 
-Note that we assume that LNG consumption will be subject to the same emissions factor as domestic natural gas. Additional emissions factors associated with regasification or leakage of LNG are not currently included. We also assume that LNG is only used for electricity generation, and explicitly limit it to this. 
+Note that we assume that LNG consumption will be subject to the same emissions factor as domestic natural gas. Additional emissions factors associated with regasification or leakage of LNG are not currently included. 
 
 Because we currently set fixed install dates for terminals, assuming a single terminal is installed in 2027, the modelling solution is straightforward. Note that if you wished to expand the method to allow the model to choose optimal installation dates for the terminal, a Mixed Integer Programming[^mip] solution would be required to ensure that no partial terminals could be constructed.
 
 [^import_limits]: We assume that the maximum annual LNG demand will never exceed the throughput of the standard terminal configuration.
 
 [^mip]: In its default state, TIMES reaches an optimal model solution as a linear programming solution. This means that it could choose to build, for example, a fraction of an LNG import terminal. This is not realistic, so we limit LNG import options to “integer states”, meaning either the entire facility is built or not at all. This requires a Mixed Integer Programming solution, which increases the computational load of the model but is necessary for plausible results.
+
+
+## Scenario Adjustments 
+
+While both scenarios include LNG import options, we adjust the cost and availability for the Transformation scenario. Here, the likely future cost is raised from 20 to 40 NZD/GJ, reflecting the potential of much higher import costs caused by global geopolitical instablity. We further create a "two-tier" market for gas in this scenario, allowing the use of LNG only for electricity generation.


### PR DESCRIPTION
Assign LNG to both scenarios, creating separate subres and scenario files. Costs are raised to 40 NZD/GJ for Transformation, and the electricity sector restrictions only apply to Transformation currently. These parameters are still subject to change. 

Note: the renaming of the scenarios mean that a modeller will need to update their Veda scenario groups to apply these changes correctly 