### PR TITLE
Restrict residential mobile motive fuel switching

### DIFF
--- a/PREPARE-TIMES-NZ/docs/source/model_methodology/residential/index.md
+++ b/PREPARE-TIMES-NZ/docs/source/model_methodology/residential/index.md
@@ -11,6 +11,7 @@ demand_projections
 technology_parameters
 new_techs
 residential_demand_curves
+topology
 appendix
 ```
 

--- a/PREPARE-TIMES-NZ/docs/source/model_methodology/residential/topology.md
+++ b/PREPARE-TIMES-NZ/docs/source/model_methodology/residential/topology.md
@@ -1,0 +1,7 @@
+# Model structure
+
+Model structure, often referred to as "topology" in TIMES parlance, defines which technologies can substitute for which uses. 
+
+By default, we assume that all technologies which currently meet a given end-use, as defined by the EEUD structure, can freely swap between each other. This mostly makes good sense - water heating demand could be met by an electric hot water cylinder, or a natural gas instant water heater. The technology or input fuel can be changed by the model, once considering the relevant efficiencies, costs, and so on. 
+
+However, there are often edge cases where strictly adhering to the structure of the underlying data makes less sense. In the residential sector, we adjust the application of mobile motive power, which is currently met by diesel and petrol. We have very little information on the precise technologies/uses that this use category entails - recreational boating, offroad vehicles, lawnmowers, etc. Because the current data is quite high-level, it would be misleading to assume there was only one kind of use that could freely swap between petrol or diesel technologies. We therefore define different use categories within the model - mobile motive diesel, and mobile motive petrol. This means that there can be no fuel switching between these specific categories. 

--- a/PREPARE-TIMES-NZ/src/prepare_times_nz/stage_2/residential/generate_process_names.py
+++ b/PREPARE-TIMES-NZ/src/prepare_times_nz/stage_2/residential/generate_process_names.py
@@ -61,10 +61,18 @@ def define_residential_process_commodities(
     ].agg("-".join, axis=1)
 
     df["CommodityIn"] = "RES" + df[["Fuel_TIMES"]].agg("-".join, axis=1)
-    # NOTE: All output commodities are tech-agnostic in the residential sector
+    # Output commodities are usually tech- and fuel-agnostic in the residential
+    # sector, except for motive power where the fuel needs to remain explicit.
+    # We do this because we have poor understanding of the underlying techs/uses,
+    # so this approach means there can be no switching between diesel/petrol motive power
     df["CommodityOut"] = df[["DwellingType_TIMES", "EndUse_TIMES"]].agg(
         "-".join, axis=1
     )
+    motive_power_mobile_mask = df["EndUse"] == "Motive Power, Mobile"
+    df.loc[motive_power_mobile_mask, "CommodityOut"] = df.loc[
+        motive_power_mobile_mask,
+        ["DwellingType_TIMES", "Fuel_TIMES", "EndUse_TIMES"],
+    ].agg("-".join, axis=1)
 
     return df[["Process", "CommodityIn", "CommodityOut"] + original_columns]
 
@@ -80,3 +88,7 @@ def main():
     df = pd.read_csv(PREPROCESSING_DIR / PREPRO_DF_NAME_STEP3)
     df = define_residential_process_commodities(df)
     save_preprocessing(df, PREPRO_DF_NAME_STEP4, "Residential process data")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Lock residential mobile motive power shares for diesel and petrol in place by defining separate end use categories for these. Justify methods in residential topology documentation 
