### PR TITLE
Lock other industry

### DIFF
--- a/PREPARE-TIMES-NZ/data_raw/concordances/industry/times_eeud_tech_renames.toml
+++ b/PREPARE-TIMES-NZ/data_raw/concordances/industry/times_eeud_tech_renames.toml
@@ -15,8 +15,6 @@ Justification = "Redefining Geothermal Boilers as Heat Exchangers"
   [rule.updates]
   Technology = "Heat Exchangers"
 
-
-
 [[rule]]
 Name = "Ballance Compressors"
 Justification = "Declaring Ballance's pumps as Compressors for clarity"
@@ -29,8 +27,6 @@ Justification = "Declaring Ballance's pumps as Compressors for clarity"
   [rule.updates]
   Technology = "Compressors"
 
-
-
 [[rule]]
 Name = "Labelling all the Methanex use as reforming"
 Justification = "We have allocated a lot of use to Methanex, but don't trust the implied share detail, so we call it all reforming"
@@ -39,7 +35,6 @@ Justification = "We have allocated a lot of use to Methanex, but don't trust the
   Sector = "Methanol"
   Fuel = "Natural Gas"
   EndUse = "High Temperature Heat (>300 C), Process Requirements"  
-
 
   [rule.updates]  
   # note inconsistent pluralisation in the main data 
@@ -65,8 +60,7 @@ Justification = "There should not be high temp ele use in this sector - suspect 
 Name = "Heat pumps for space heating"
 Justification = "We distinguish different technologies for heatpumps for space heating v space cooling"
 
-  [rule.conditions]     
-  
+  [rule.conditions]       
   Technology = "Heat Pump (for Heating)"
   EndUse = "Low Temperature Heat (<100 C), Space Heating"
 
@@ -77,25 +71,31 @@ Justification = "We distinguish different technologies for heatpumps for space h
 [[rule]]
 Name = "Heat pumps for process heating"
 Justification = "We distinguish different technologies for heatpumps for space heating v space cooling"
-
-  [rule.conditions]     
-  
+  [rule.conditions]       
   Technology = "Heat Pump (for Heating)"
   EndUse = "Low Temperature Heat (<100 C), Process Requirements"
-
   [rule.updates]  
   Technology = "Heat Pump (process heat)"
 
-
-
 [[rule]]
 Name = "Combine water heating and low temperature process heat in industry"
-Justification = "This is not a useful distinction"
-
-
+Justification = "This is not a useful distinction, because water heating is process heat"
   [rule.conditions]
   SectorGroup = "Industrial"
   EndUse = "Low Temperature Heat (<100 C), Water Heating"
-
   [rule.updates]
+  EndUse = "Low Temperature Heat (<100 C), Process Requirements"
+
+
+[[rule]]
+Name = "Remove other industry burner space heating"
+Justification = "The data on this is dubious, so we re-assign this to the process heat bucket as a boiler"
+
+  [rule.conditions]
+  SectorGroup = "Industrial"
+  Sector = "Other Industry"
+  Technology = "Burner (Direct Heat)"
+  EndUse = "Low Temperature Heat (<100 C), Space Heating"
+  [rule.updates]
+  Technology = "Boiler Systems"
   EndUse = "Low Temperature Heat (<100 C), Process Requirements"

--- a/PREPARE-TIMES-NZ/data_raw/user_config/base_year/VT_TIMESNZ_IND.toml
+++ b/PREPARE-TIMES-NZ/data_raw/user_config/base_year/VT_TIMESNZ_IND.toml
@@ -25,17 +25,23 @@ SheetName = "Industry demand"
 TagName = "FI_Process"
 DataLocation = "data_intermediate/stage_4_veda_format/base_year_ind/demand_process_definitions.csv"
 
-[IndustryDemand]
+[IndustryDemandTopology]
 Description = "Industry base year demand topology and technical parameters"
 SheetName = "Industry demand"
 TagName = "FI_T"
 DataLocation = "data_intermediate/stage_4_veda_format/base_year_ind/industry_baseyear_details.csv"
 
-[IndustryDemand2]
+[IndustryCommodityDemand]
 Description = "Industry total commodity demand (met by activity bound per process)"
 SheetName = "Industry demand"
 TagName = "FI_T: Demand"
 DataLocation = "data_intermediate/stage_4_veda_format/base_year_ind/industry_commodity_demand.csv"
+
+[IndustryOtherDemand]
+Description = "Locks 'Other Industry' fuel shares in place. Data on this unallocated demand is poor and true flexibility leads to unrealistic results."
+SheetName = "Industry demand"
+TagName = "FI_T"
+DataLocation = "data_intermediate/stage_4_veda_format/base_year_ind/lock_other_industry.csv"
 
 ###############################################################################
 # Fuel Delivery

--- a/PREPARE-TIMES-NZ/docs/source/changelog.md
+++ b/PREPARE-TIMES-NZ/docs/source/changelog.md
@@ -21,6 +21,7 @@
 - Resolved an error which led to excessive technology inflexibility in transport utilisation constraints. This allows for more realistic purchasing behaviour across different utilisation categories.
 - Disabled excessive optimisation of energy service demand between timeslices, which was leading to unrealistic demand flex behaviour. Note that this change also disables ESD timeslice reporting. 
 - Corrected several links in biogas topology. 
+- Resolved an issue that was leading to unrealistic switching behaviour in Other Industry demand.
 
 ## 3.0.4
 

--- a/PREPARE-TIMES-NZ/docs/source/model_methodology/industry/historic_demand.md
+++ b/PREPARE-TIMES-NZ/docs/source/model_methodology/industry/historic_demand.md
@@ -259,6 +259,7 @@ In addition to recategorising sectors and adding some missing demand, we make th
  - All direct use of natural gas at Methanex is labelled “Reformers”.
  - The EEUD shows that there is some high temperature (over 300°C) process heat use in the wood processing sector. This uses electricity, and the total demand is very low; roughly 3TJ in 2023. As there should be no process heat over 300°C in this sector, we believe this may be a category error, and recategorise it as intermediate heat (100°C-300°C) provided by electric boilers.
  - All Low Temperature Heat (<100 C), Water Heating is combined to low temperature process heat in industry.
+ - Some unallocated ("Other Industry") end use demands are simplified, as the data in unallocated demand sectors is less robust.
 
 ## Island demand shares 
 

--- a/PREPARE-TIMES-NZ/src/prepare_times_nz/stage_2/common/add_tech_assumptions.py
+++ b/PREPARE-TIMES-NZ/src/prepare_times_nz/stage_2/common/add_tech_assumptions.py
@@ -12,16 +12,18 @@ from prepare_times_nz.utilities.logger_setup import logger
 BASE_YEAR = 2023
 CAP2ACT = 31.536
 RUN_TESTS = True
+REPORT_CONSOLE_WARNINGS = False
 
 
 def check_missing_lifetimes(df: pd.DataFrame) -> None:
     """Log warning for technologies missing lifetime data."""
     missing_techs = df[df["Life"].isna()]["Technology"].drop_duplicates()
-    if not missing_techs.empty:
-        logger.warning("The following technologies have no lifetimes:")
-        for tech in missing_techs:
-            logger.warning("    '%s'", tech)
-        logger.warning("These will have infinite lifetimes in the model.")
+    if REPORT_CONSOLE_WARNINGS:
+        if not missing_techs.empty:
+            logger.warning("The following technologies have no lifetimes:")
+            for tech in missing_techs:
+                logger.warning("    '%s'", tech)
+            logger.warning("These will have infinite lifetimes in the model.")
 
 
 def add_lifetimes(
@@ -43,11 +45,12 @@ def check_missing_efficiencies(
 ) -> None:
     """Log warning for technologies missing efficiency data."""
     missing_eff = df[df["Efficiency"].isna()][list(cols)].drop_duplicates()
-    if not missing_eff.empty:
-        logger.warning("Technologies with missing efficiency:")
-        for _, row in missing_eff.iterrows():
-            formatted = " | ".join(f"'{row[c]}'" for c in cols)
-            logger.warning("    %s", formatted)
+    if REPORT_CONSOLE_WARNINGS:
+        if not missing_eff.empty:
+            logger.warning("Technologies with missing efficiency:")
+            for _, row in missing_eff.iterrows():
+                formatted = " | ".join(f"'{row[c]}'" for c in cols)
+                logger.warning("    %s", formatted)
 
 
 def add_efficiencies(
@@ -68,10 +71,11 @@ def check_missing_capex(
 ) -> None:
     """Log warning for processes/technologies missing capital cost data."""
     missing_capex = df[df["CAPEX"].isna()][list(cols)].drop_duplicates()
-    if not missing_capex.empty:
-        logger.warning("Processes with missing capital cost:")
-        for _, row in missing_capex.iterrows():
-            logger.warning("    %s", " | ".join(f"'{row[c]}'" for c in cols))
+    if REPORT_CONSOLE_WARNINGS:
+        if not missing_capex.empty:
+            logger.warning("Processes with missing capital cost:")
+            for _, row in missing_capex.iterrows():
+                logger.warning("    %s", " | ".join(f"'{row[c]}'" for c in cols))
 
 
 def add_capex(
@@ -98,10 +102,11 @@ def check_missing_opex(
 ) -> None:
     """Log warning for processes/technologies missing operating cost data."""
     missing_opex = df[df["OPEX"].isna()][list(cols)].drop_duplicates()
-    if not missing_opex.empty:
-        logger.warning("Processes with missing operating cost:")
-        for _, row in missing_opex.iterrows():
-            logger.warning("    %s", " | ".join(f"'{row[c]}'" for c in cols))
+    if REPORT_CONSOLE_WARNINGS:
+        if not missing_opex.empty:
+            logger.warning("Processes with missing operating cost:")
+            for _, row in missing_opex.iterrows():
+                logger.warning("    %s", " | ".join(f"'{row[c]}'" for c in cols))
 
 
 def add_opex(

--- a/PREPARE-TIMES-NZ/src/prepare_times_nz/stage_4/baseyear/industrial.py
+++ b/PREPARE-TIMES-NZ/src/prepare_times_nz/stage_4/baseyear/industrial.py
@@ -235,6 +235,55 @@ def define_fuel_delivery(df):
     )
 
 
+# "Other" industry flo_shares
+
+
+def lock_other_industry(df, exceptions, slack=0.01):
+    """
+    Identifies "other" industry and creates FLO_MARKs
+    to lock demand splits over time
+
+    Adds a new column with each process's share of total output
+    within its CommodityOut group.
+
+    We list exceptions for specific input commodities:
+    For these we add no lower bounds
+
+    We also add a slack variable - allowing production to fall
+    x% lower than the share provided
+    This is mostly just to help the model perform a little easier
+    (rigidity makes for slower solves)
+    """
+    # other industry output energy
+    df = df[df["Sector"] == "Other Industry"].copy()
+    df = df[df["Variable"] == "OutputEnergy"]
+
+    # get process shares of production
+    df["Total"] = df.groupby(["Region", "CommodityOut"])["Value"].transform("sum")
+    df["Share"] = np.where(
+        df["Total"] != 0,
+        df["Value"] / df["Total"],
+        0,
+    )
+    # apply slack to share
+    df["Share"] = df["Share"] * (1 - slack)
+    # remove lower bound qualifiers for our exceptions
+    df["Share"] = np.where(df["CommodityIn"].isin(exceptions), 0, df["Share"])
+
+    # column renaming
+    flo_mark_map = {
+        "Process": "TechName",
+        "CommodityOut": "Comm-OUT",
+        "Region": "Region",
+        "Share": "FLO_MARK~LO",
+    }
+    df = select_and_rename(df, flo_mark_map)
+    # add interp
+    df["FLO_MARK~LO~0"] = 5
+
+    return df
+
+
 # Main ----------------------------------------------------------------------
 
 
@@ -256,12 +305,21 @@ def main():
     agg_df = get_commodity_demand(ind_veda)
 
     # main table
-
     save_industry_veda_file(
         agg_df,
         name="industry_commodity_demand.csv",
         label="industry commodity demand",
     )
+    # locking other industry
+
+    other_industry = lock_other_industry(raw_df, exceptions=["INDNGA", "INDCOA"])
+
+    save_industry_veda_file(
+        other_industry,
+        name="lock_other_industry.csv",
+        label="'Other Industry' locks",
+    )
+
     # commodity definitions for fi_comm
     # (Note emissions commodity declared directly in user config file)
     define_enduse_commodities(


### PR DESCRIPTION
Adds FLO_MARKS to "Other Industry" demand, limiting fuel switching in this sector. The idea is that we are less convinced of the data quality in unallocated industrial demand, so we limit the model's flexibility to ensure more realistic results. 